### PR TITLE
[Fix #2] Rehydrated get render prop and backward compatible to existi…

### DIFF
--- a/packages/aws-appsync-react/src/rehydrated-rn.tsx
+++ b/packages/aws-appsync-react/src/rehydrated-rn.tsx
@@ -14,8 +14,8 @@ import AWSAppSyncClient from 'aws-appsync';
 
 export interface RehydrateProps {
     rehydrated: boolean;
-    children: any,
-    style: any,
+    children: React.ReactNode;
+    style: any;
 }
 
 const Rehydrate = (props: RehydrateProps) => (
@@ -35,15 +35,23 @@ interface RehydratedState {
 }
 
 export interface RehydratedProps {
-    rehydrated: boolean;
-    children: any,
-    style: any,
+    render?: ((props: { rehydrated: boolean }) => React.ReactNode);
+    children?: React.ReactChildren;
+    loading?: React.ComponentType<any>;
+    style?: any;
 }
 
 export default class Rehydrated extends React.Component<RehydratedProps, RehydratedState> {
 
     static contextTypes = {
         client: PropTypes.instanceOf(AWSAppSyncClient).isRequired,
+    };
+
+    static propTypes = {
+        render: PropTypes.func,
+        children: PropTypes.node,
+        loading: PropTypes.node,
+        style: View.propTypes.style,
     };
 
     constructor(props, context) {
@@ -64,10 +72,19 @@ export default class Rehydrated extends React.Component<RehydratedProps, Rehydra
     }
 
     render() {
-        return (
-            <Rehydrate rehydrated={this.state.rehydrated} style={this.props.style} >
-                {this.props.children}
-            </Rehydrate>
-        );
+        const { render, children, loading, style } = this.props;
+        const { rehydrated } = this.state;
+
+        if (render) return render({ rehydrated });
+
+        if (children) {
+            if (loading) return rehydrated ? children : loading;
+
+            return (
+                <Rehydrate rehydrated={rehydrated} style={style} >
+                    {children}
+                </Rehydrate>
+            );
+        }
     }
 }

--- a/packages/aws-appsync-react/src/rehydrated.tsx
+++ b/packages/aws-appsync-react/src/rehydrated.tsx
@@ -13,7 +13,7 @@ import AWSAppSyncClient from 'aws-appsync';
 
 export interface RehydrateProps {
     rehydrated: boolean;
-    children: any,
+    children: React.ReactNode,
 }
 
 const Rehydrate = (props: RehydrateProps) => (
@@ -26,10 +26,21 @@ interface RehydratedState {
     rehydrated: boolean
 }
 
-export default class Rehydrated extends React.Component<void, RehydratedState> {
+export interface RehydratedProps {
+    render?: ((props: { rehydrated: boolean }) => React.ReactNode);
+    children?: React.ReactChildren;
+    loading?: React.ComponentType<any>;
+}
 
+export default class Rehydrated extends React.Component<RehydratedProps, RehydratedState> {
     static contextTypes = {
         client: PropTypes.instanceOf(AWSAppSyncClient).isRequired,
+    };
+
+    static propTypes = {
+        render: PropTypes.func,
+        children: PropTypes.node,
+        loading: PropTypes.node,
     };
 
     constructor(props, context) {
@@ -49,10 +60,19 @@ export default class Rehydrated extends React.Component<void, RehydratedState> {
     }
 
     render() {
-        return (
-            <Rehydrate rehydrated={this.state.rehydrated}>
-                {this.props.children}
-            </Rehydrate>
-        );
+        const { render, children, loading } = this.props;
+        const { rehydrated } = this.state;
+
+        if (render) return render({ rehydrated });
+
+        if (children) {
+            if (loading) return rehydrated ? children : loading;
+
+            return (
+                <Rehydrate rehydrated={this.state.rehydrated}>
+                    {children}
+                </Rehydrate>
+            );
+        }
     }
 }

--- a/packages/aws-appsync-react/src/rehydrated.tsx
+++ b/packages/aws-appsync-react/src/rehydrated.tsx
@@ -69,7 +69,7 @@ export default class Rehydrated extends React.Component<RehydratedProps, Rehydra
             if (loading) return rehydrated ? children : loading;
 
             return (
-                <Rehydrate rehydrated={this.state.rehydrated}>
+                <Rehydrate rehydrated={rehydrated}>
                     {children}
                 </Rehydrate>
             );


### PR DESCRIPTION
Possible use cases:

1) Altering App and LoadingComponent
```javascript
<Rehydrated
  render={(props) => props.rehydrated ? <App /> : <LoadingComponent />}
  //  render={(props) => <App isLoading={props.rehydrated} />} here we aren't blocking App, 
  //  just showing loading in some place
/>
```

2) Custom LoadingComponent and children
```javascript
<Rehydrated loading={LoadingComponent}>
   <App />
</Rehydrated>
```

3) Fallback to previous version (neither render or LoadingComponent not used).