### PR TITLE
Add Error Link to ease troubleshooting

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -21,6 +21,7 @@
     "apollo-client": "^2.0.3",
     "apollo-link": "^1.0.0",
     "apollo-link-context": "^1.0.0",
+    "apollo-link-error": "^1.0.3",
     "apollo-link-http": "^1.0.0",
     "aws-sdk": "^2.139.0",
     "graphql": "^0.11.7",

--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -10,6 +10,7 @@ import ApolloClient, { ApolloClientOptions, MutationOptions } from 'apollo-clien
 import { NormalizedCache } from 'apollo-cache-inmemory';
 import { ApolloLink, FetchResult } from 'apollo-link';
 import { HttpLink } from 'apollo-link-http';
+import { onError } from "apollo-link-error";
 import { getMainDefinition, getOperationDefinition, variablesInOperation } from 'apollo-utilities';
 
 import { Action, applyMiddleware, createStore, compose, combineReducers, Store } from 'redux';
@@ -100,6 +101,16 @@ class AWSAppSyncClient extends ApolloClient {
         const cache = new InMemoryCache(store);
 
         let link = ApolloLink.from([
+            new onError(({ graphQLErrors, networkError }) => {
+                if (graphQLErrors)
+                    graphQLErrors.map(({ message, locations, path }) =>
+                        console.log(
+                            `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
+                        ),
+                    );
+              
+                if (networkError) console.log(`[Network error]: ${networkError}`);
+            }),            
             new OfflineLink(store),
             new ComplexObjectLink(complexObjectsCredentials),
             new AuthLink({ url, region, auth }),

--- a/packages/aws-appsync/yarn.lock
+++ b/packages/aws-appsync/yarn.lock
@@ -61,6 +61,12 @@ apollo-link-dedup@^1.0.0:
   dependencies:
     apollo-link "^1.0.7"
 
+apollo-link-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.0.3.tgz#2c679d2e6a2df09a9ae3f70d23c64af922a801a2"
+  dependencies:
+    apollo-link "^1.0.6"
+
 apollo-link-http@^1.0.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.3.2.tgz#63537ee5ecf9c004efb0317f1222b7dbc6f21559"


### PR DESCRIPTION
Per the Apollo client doc, you can utilize the Error Link to get details on GraphQL and network errors.

https://github.com/apollographql/apollo-client/blob/master/docs/source/features/error-handling.md

Small adjustment to include this as I'm hitting some problems and it really helps to get more clues on what's going sideways.