### PR TITLE
Fix webpack errors using `this` before `super`

### DIFF
--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -85,7 +85,7 @@ class AWSAppSyncClient extends ApolloClient {
         }
 
         let res;
-        this.hydratedPromise = new Promise((resolve, reject) => {
+        const hydratedPromise = new Promise((resolve, reject) => {
             res = resolve;
         });
 
@@ -127,6 +127,7 @@ class AWSAppSyncClient extends ApolloClient {
 
         super(newOptions);
 
+        this.hydratedPromise = hydratedPromise;
         this.aasStore = store;
     }
 

--- a/packages/aws-appsync/src/link/non-terminating-http-link.js
+++ b/packages/aws-appsync/src/link/non-terminating-http-link.js
@@ -17,6 +17,7 @@ export class NonTerminatingHttpLink extends ApolloLink {
     link;
 
     constructor(contextKey, options) {
+        super();
         this.contextKey = contextKey;
         this.link = createHttpLink(options);
     }

--- a/packages/aws-appsync/src/link/offline-link.js
+++ b/packages/aws-appsync/src/link/offline-link.js
@@ -26,6 +26,7 @@ export class OfflineLink extends ApolloLink {
      * @param {Store} store 
      */
     constructor(store) {
+        super();
         this.store = store;
     }
 

--- a/packages/aws-appsync/src/link/subscription-handshake-link.js
+++ b/packages/aws-appsync/src/link/subscription-handshake-link.js
@@ -43,6 +43,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
     topicObserver = new Map();
 
     constructor(subsInfoContextKey) {
+        super();
         this.subsInfoContextKey = subsInfoContextKey;
     }
 


### PR DESCRIPTION
Fixes webpack errors like the following:

![image](https://user-images.githubusercontent.com/213125/35474219-414b96dc-0359-11e8-95c0-98913e1fc169.png)

