### PR TITLE
Make offline support optional

### DIFF
--- a/packages/aws-appsync/package-lock.json
+++ b/packages/aws-appsync/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@types/async": {
-      "version": "2.0.45",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.45.tgz",
-      "integrity": "sha512-Gul4iUqYqrQQypJpwjqR24dcgJAAjvwncznGBGrINmcz73eHLWkmE8/YGAo4Dr0ADKBCBlkA+f58plzFIh6XAA==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.47.tgz",
+      "integrity": "sha512-/mQMARXVSuGbwOFFBKA4s0qRKtOaaTgnllp3qU4sMzDVGGAroPblyd529yBALnK/WEY8nHyRGx0/RFUDmhpVmQ==",
       "optional": true
     },
     "@types/node": {
@@ -49,18 +49,38 @@
       }
     },
     "apollo-client": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.0.3.tgz",
-      "integrity": "sha512-ZPyGYgewnFlSCArwfBVsNnEjt/Qvr8zvisQM1sFZtkcateKkGou4bk+JihFtjXNmYlWx50z+X71DI0VP34Mh8Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.2.1.tgz",
+      "integrity": "sha512-zc8ovUQEDaD/1gFU8NF172Uj/lR4XFFNC4zTh3WTlBHitS7laDBeHsg92ujbRHD96wWeFgaFQPBwn1y7lqPksA==",
       "requires": {
-        "@types/async": "2.0.45",
+        "@types/async": "2.0.47",
         "@types/zen-observable": "0.5.3",
-        "apollo-cache": "1.0.1",
+        "apollo-cache": "1.1.1",
         "apollo-link": "1.0.3",
-        "apollo-link-dedup": "1.0.2",
-        "apollo-utilities": "1.0.2",
+        "apollo-link-dedup": "1.0.5",
+        "apollo-utilities": "1.0.5",
         "symbol-observable": "1.1.0",
-        "zen-observable": "0.6.0"
+        "zen-observable": "0.7.1"
+      },
+      "dependencies": {
+        "apollo-cache": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.1.tgz",
+          "integrity": "sha512-LZJaOkH2pDr00xaqkphDpQ5QlnQDSCfVEQ/e80Z2eZz6mbL7vDPQFqVq2YNp6DOFoVc0+CALzLALs+BWNIa7+A==",
+          "requires": {
+            "apollo-utilities": "1.0.5"
+          }
+        },
+        "apollo-utilities": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.5.tgz",
+          "integrity": "sha512-7O99ZQ39kCUUHO7PD7pega1bHtIfkJCATEWb88nIqr0qw7NXSzwKYAgklWVPAryYfHpy/pw39MD7fjhcL2N06g=="
+        },
+        "zen-observable": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
+          "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
+        }
       }
     },
     "apollo-link": {
@@ -79,9 +99,24 @@
       "integrity": "sha512-6irajvNlVpnJLSzTGrqIBEvRq901u5Jte6IDYbO/DwiGFMrbNbKjwbR2Nf92YzNWy9anmvtsmoz39oaGykBkIA=="
     },
     "apollo-link-dedup": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.2.tgz",
-      "integrity": "sha512-ECzXORE+fk+kjf+zOugcfaa9Tf/mX+vpNZa+oVAuKhzmRaWST3wsm6TUNfQOx25mF4g3ocw0Kv2OIa921TSKIw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz",
+      "integrity": "sha512-KxBC8RapBctNX7o/bxMi5LdLA5VhD9ng8Td0tG+zlib5WV5wMERBCclgd9LqRdt1CkxJ/gsrTfBh38LcVhpWvg==",
+      "requires": {
+        "apollo-link": "1.0.7"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.0.7.tgz",
+          "integrity": "sha512-oHzvpIDEy4UCNdbOw42wtOK1zOzdMrt4ulYyon24zT24MjicezTmXqJh2mR6whTl8RiUDLDY4ByusdKKXdcqHw==",
+          "requires": {
+            "@types/zen-observable": "0.5.3",
+            "apollo-utilities": "1.0.2",
+            "zen-observable": "0.6.0"
+          }
+        }
+      }
     },
     "apollo-link-http": {
       "version": "1.2.0",

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@redux-offline/redux-offline": "^2.2.1",
     "apollo-cache-inmemory": "^1.0.0",
-    "apollo-client": "^2.0.3",
+    "apollo-client": "^2.2.1",
     "apollo-link": "^1.0.0",
     "apollo-link-context": "^1.0.0",
     "apollo-link-http": "^1.0.0",

--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -7,63 +7,16 @@
  * KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 import ApolloClient, { ApolloClientOptions, MutationOptions } from 'apollo-client';
-import { NormalizedCache } from 'apollo-cache-inmemory';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloLink, FetchResult } from 'apollo-link';
 import { HttpLink } from 'apollo-link-http';
 import { getMainDefinition, getOperationDefinition, variablesInOperation } from 'apollo-utilities';
 
-import { Action, applyMiddleware, createStore, compose, combineReducers, Store } from 'redux';
-import { offline } from '@redux-offline/redux-offline';
-import offlineConfig from '@redux-offline/redux-offline/lib/defaults';
-import thunk from 'redux-thunk';
-
-import InMemoryCache, { reducer as cacheReducer, NORMALIZED_CACHE_KEY } from './cache/index';
+import OfflineCache from './cache/index';
 import { OfflineLink, AuthLink, NonTerminatingHttpLink, SubscriptionHandshakeLink, ComplexObjectLink } from './link';
-import { reducer as commitReducer, offlineEffect, discard } from './link/offline-link';
-
-/**
- * 
- * @param {Function} persistCallback 
- * @param {*} effect
- * @returns {Store<NormalizedCache>}
- */
-const newStore = (persistCallback = () => null, effect, discard) => {
-    return createStore(
-        combineReducers({
-            rehydrated: (state = false, action) => {
-                switch (action.type) {
-                    case 'REHYDRATE_STORE':
-                        return true;
-                    default:
-                        return state;
-                }
-            },
-            ...cacheReducer(),
-            ...commitReducer(),
-        }),
-        window && window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : {},
-        compose(
-            applyMiddleware(thunk),
-            offline({
-                ...offlineConfig,
-                persistCallback,
-                persistOptions: {
-                    whitelist: [NORMALIZED_CACHE_KEY, 'offline']
-                },
-                effect,
-                discard,
-            })
-        )
-    );
-};
+import { createStore } from './store';
 
 class AWSAppSyncClient extends ApolloClient {
-
-    /**
-     * @type {Store<{}>}
-     * @private
-     */
-    aasStore;
 
     /**
      * @type {Promise<AWSAppSyncClient>}
@@ -77,11 +30,11 @@ class AWSAppSyncClient extends ApolloClient {
      * @param {string} url 
      * @param {ApolloClientOptions<InMemoryCache>} options
      */
-    constructor({ url, region, auth, conflictResolver, complexObjectsCredentials }, options) {
+    constructor({ url, region, auth, conflictResolver, complexObjectsCredentials, disableOffline = false }, options) {
         if (!url || !region || !auth) {
-            throw new Error(`
-                In order to initialize AWSAppSyncClient, you must specify url, region and auth properties on the config object.
-            `);
+            throw new Error(
+                'In order to initialize AWSAppSyncClient, you must specify url, region and auth properties on the config object.'
+            );
         }
 
         let res;
@@ -89,18 +42,19 @@ class AWSAppSyncClient extends ApolloClient {
             res = resolve;
         });
 
-        const store = newStore(
+        const store = disableOffline ? null : createStore(
+            this,
             () => {
-                this.aasStore.dispatch({ type: 'REHYDRATE_STORE' });
+                store.dispatch({ type: 'REHYDRATE_STORE' });
                 res(this);
             },
-            (effect, action) => offlineEffect(this, effect, action),
-            discard(conflictResolver),
+            conflictResolver,
         );
-        const cache = new InMemoryCache(store);
+        const cache = disableOffline ? new InMemoryCache() : new OfflineCache(store);
 
+        const passthrough = (op, forward) => (forward ? forward(op) : Observable.of());
         let link = ApolloLink.from([
-            new OfflineLink(store),
+            disableOffline ? passthrough : new OfflineLink(store),
             new ComplexObjectLink(complexObjectsCredentials),
             new AuthLink({ url, region, auth }),
             ApolloLink.split(
@@ -127,7 +81,9 @@ class AWSAppSyncClient extends ApolloClient {
 
         super(newOptions);
 
-        this.aasStore = store;
+        if (disableOffline) {
+            res(this);
+        }
     }
 
     /**

--- a/packages/aws-appsync/src/store.js
+++ b/packages/aws-appsync/src/store.js
@@ -1,0 +1,48 @@
+import { Action, applyMiddleware, createStore, compose, combineReducers, Store } from 'redux';
+import { offline } from '@redux-offline/redux-offline';
+import offlineConfig from '@redux-offline/redux-offline/lib/defaults';
+import thunk from 'redux-thunk';
+
+import { AWSAppSyncClient } from './client';
+import { reducer as cacheReducer, NORMALIZED_CACHE_KEY } from './cache/index';
+import { reducer as commitReducer, offlineEffect, discard } from './link/offline-link';
+
+/**
+ * 
+ * @param {AWSAppSyncClient} client
+ * @param {Function} persistCallback 
+ * @param {Function} conflictResolver 
+ */
+const newStore = (client, persistCallback = () => null, conflictResolver) => {
+    return createStore(
+        combineReducers({
+            rehydrated: (state = false, action) => {
+                switch (action.type) {
+                    case 'REHYDRATE_STORE':
+                        return true;
+                    default:
+                        return state;
+                }
+            },
+            ...cacheReducer(),
+            ...commitReducer(),
+        }),
+        typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+        compose(
+            applyMiddleware(thunk),
+            offline({
+                ...offlineConfig,
+                persistCallback,
+                persistOptions: {
+                    whitelist: [NORMALIZED_CACHE_KEY, 'offline']
+                },
+                effect: (effect, action) => offlineEffect(client, effect, action),
+                discard: discard(conflictResolver),
+            })
+        )
+    );
+};
+
+export {
+    newStore as createStore
+}


### PR DESCRIPTION
Adds the `disableOffline` option to the client to disable offline support

```javascript
const client = new AWSAppSyncClient({
  disableOffline: true,
  url: appSyncConfig.graphqlEndpoint,
  region: appSyncConfig.region,
  auth: {
    type: appSyncConfig.authenticationType,
    apiKey: appSyncConfig.apiKey,
  }
});
```