### PR TITLE
Preserve the observer associated with an existing topic

### DIFF
--- a/packages/aws-appsync/README.md
+++ b/packages/aws-appsync/README.md
@@ -1,1 +1,11 @@
-# aws-appsync
+# Changelog
+
+### vNext
+- Fix AWS_IAM credentials fetching [PR#XX](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/XX)
+- Preserve the observer associated with an existing topic [PR#37](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/37)
+
+### 1.0.8
+- Handle missing optimisticResponse [PR#34](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/34)
+
+### 1.0.7 
+- Make offline support optional [PR#33](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/33)


### PR DESCRIPTION
when a new request is executed, we need to make sure the observer intially associated with a topic is preserved. currently, on a new request, we disconnect all the clients and then reconnect them and associate them with the **latest** observer. When a subscription message is received, we then fetchthe observer with:

`this.topicObserver.get(topic);`

and call

`observer.next(parsedMessage);`

which will trigger a specific handler configured for that observer (the handler that subscribed to the observer returned by the `execute` function in `QueryManager.startGraphQLSubscription`.

The change keeps track of the previous value of `topicObserver` and retains the observer associated with an existing topic.
