### PR TITLE
change View.propTypes (deprecated) to ViewPropTypes

### DIFF
--- a/packages/aws-appsync-react/src/rehydrated-rn.tsx
+++ b/packages/aws-appsync-react/src/rehydrated-rn.tsx
@@ -51,7 +51,7 @@ export default class Rehydrated extends React.Component<RehydratedProps, Rehydra
         render: PropTypes.func,
         children: PropTypes.node,
         loading: PropTypes.node,
-        style: View.propTypes.style,
+        style: ViewPropTypes.style,
     };
 
     constructor(props, context) {


### PR DESCRIPTION
-change View.propTypes (deprecated to ViewPropTypes
-this deprecation causes an error in newer react-native version (found on 0.53.3)