### PR TITLE
Delete observer associated with a topic when cleanup function is called

### DIFF
--- a/packages/aws-appsync/CHANGELOG.md
+++ b/packages/aws-appsync/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNext
 - Inconsistent store [PR#43](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/43)
+- Delete observer associated with a topic when cleanup function is called [PR#60](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/60)
 
 ### 1.0.11
 - Add setimmediate as a dependency [PR#47](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/47)

--- a/packages/aws-appsync/src/link/subscription-handshake-link.js
+++ b/packages/aws-appsync/src/link/subscription-handshake-link.js
@@ -84,7 +84,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
             return () => {
                 const [topic,] = Array.from(this.topicObserver).find(([topic, obs]) => obs === observer) || [];
 
-                const [client,] = Array.from(this.clientTopics).find(([client, t]) => t == topic) || [];
+                const [client,] = Array.from(this.clientTopics).find(([client, t]) => t.indexOf(topic) > -1) || [];
 
                 if (client && topic) {
                     this.unsubscribeFromTopic(client, topic);
@@ -107,26 +107,16 @@ export class SubscriptionHandshakeLink extends ApolloLink {
         return new Promise((resolve, reject) => {
             if (!client.isConnected()) {
                 const topics = this.clientTopics.get(client).filter(t => t !== topic);
-                if (topics.length > 0) {
-                  this.clientTopics.set(client, topics);
-                } else {
-                  this.clientTopics.delete(client);
-                }
+                this.clientTopics.set(client, topics);
                 this.topicObserver.delete(topic);
-
                 return resolve(topic);
             }
 
             client.unsubscribe(topic, {
                 onSuccess: () => {
                     const topics = this.clientTopics.get(client).filter(t => t !== topic);
-                    if (topics.length > 0) {
-                      this.clientTopics.set(client, topics);
-                    } else {
-                      this.clientTopics.delete(client);
-                    }
+                    this.clientTopics.set(client, topics);
                     this.topicObserver.delete(topic);
-
                     resolve(topic);
                 },
                 onFailure: reject,


### PR DESCRIPTION
Multiple topics can be associated with a client. This happens when
multiple subscriptions are live on a single API. In that case,
clientTopics holds client => [topics]. When the cleanup function is
called, we should look for a topic within an existing list of topics
associated with the client to identify it. Doing this allows us to find
the correct <topic, client> pair which allows us to unsubsribe the
client from the topic and remove the observer tied to the topic. Leaving
a "completed" observer in `topicObserver` will lead to it being reused
if we cancel a subscription and then switch back to it. However since
the observer has been "completed", its `next` function would never be
called.

In `unsubscribeFromTopic` function, we should not delete a `client` key if the
list of subscribed topics is empty: the client has not been disconnected
yet. The client will be disconnected when `disconnectAll` is called the
next time `request` is invoked (next subscription setup).