### PR TITLE
Update complex-object-link.js to handle 'null' values

### DIFF
--- a/packages/aws-appsync/CHANGELOG.md
+++ b/packages/aws-appsync/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### vNext
+- Update complex-object-link.js to handle 'null' values [PR#67](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/67)
+
 ### 1.0.12
 - Inconsistent store [PR#43](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/43)
 - Delete observer associated with a topic when cleanup function is called [PR#60](https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/60)

--- a/packages/aws-appsync/src/link/complex-object-link.js
+++ b/packages/aws-appsync/src/link/complex-object-link.js
@@ -89,7 +89,7 @@ const findInObject = obj => {
         return Object.keys(obj).find(key => {
             const val = obj[key];
 
-            if (typeof val === 'object') {
+            if (val && typeof val === 'object') {
                 const hasFields = complexObjectFields.every(field => {
                     const hasValue = val[field.name];
                     const types = Array.isArray(field.type) ? field.type : [field.type];


### PR DESCRIPTION
If val is null (and it could be for a mutation where you want to specifically set a field to null) this crashes as the type of null is "object" (sigh)