### PR TITLE
support Apollo cache config in AAC constructor options

### DIFF
--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -32,7 +32,7 @@ class AWSAppSyncClient extends ApolloClient {
      * @param {ApolloClientOptions<InMemoryCache>} options
      */
     constructor({ url, region, auth, conflictResolver, complexObjectsCredentials, disableOffline = false },
-                { cacheConfig = {}, ...options }) {
+                { cacheConfig = {}, ...options } = {}) {
         if (!url || !region || !auth) {
             throw new Error(
                 'In order to initialize AWSAppSyncClient, you must specify url, region and auth properties on the config object.'

--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -31,7 +31,8 @@ class AWSAppSyncClient extends ApolloClient {
      * @param {string} url
      * @param {ApolloClientOptions<InMemoryCache>} options
      */
-    constructor({ url, region, auth, conflictResolver, complexObjectsCredentials, disableOffline = false }, options) {
+    constructor({ url, region, auth, conflictResolver, complexObjectsCredentials, disableOffline = false },
+                { cacheConfig = {}, ...options }) {
         if (!url || !region || !auth) {
             throw new Error(
                 'In order to initialize AWSAppSyncClient, you must specify url, region and auth properties on the config object.'
@@ -51,7 +52,7 @@ class AWSAppSyncClient extends ApolloClient {
             },
             conflictResolver,
         );
-        const cache = disableOffline ? new InMemoryCache() : new OfflineCache(store);
+        const cache = disableOffline ? new InMemoryCache(cacheConfig) : new OfflineCache(store, cacheConfig);
 
         const passthrough = (op, forward) => (forward ? forward(op) : Observable.of());
         let link = ApolloLink.from([


### PR DESCRIPTION
I read in the React Apollo [Normalization docs](https://www.apollographql.com/docs/react/advanced/caching.html#normalization) that types without an id field need to override how apollo-cache-inmemory determines the cache key, by providing a custom dataIdFromObject to the cache constructor.

But there seems to be no way to do this with the public interface of AWSAppSyncClient, which forces its own hardcoded link and cache objects into the newOptions it sends to super() (i.e. ApolloClient).

So I shoehorned a `cacheConfig` object into the second `options` argument to the AWSAppSyncClient constructor.