### PR TITLE
Add the ability to pass custom config to redux-offline

### DIFF
--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -30,8 +30,9 @@ class AWSAppSyncClient extends ApolloClient {
      *
      * @param {string} url
      * @param {ApolloClientOptions<InMemoryCache>} options
+     * @param {object} customOfflineConfig options
      */
-    constructor({ url, region, auth, conflictResolver, complexObjectsCredentials, disableOffline = false }, options) {
+    constructor({ url, region, auth, conflictResolver, complexObjectsCredentials, disableOffline = false }, options, customOfflineConfig) {
         if (!url || !region || !auth) {
             throw new Error(
                 'In order to initialize AWSAppSyncClient, you must specify url, region and auth properties on the config object.'
@@ -50,6 +51,7 @@ class AWSAppSyncClient extends ApolloClient {
                 res(this);
             },
             conflictResolver,
+            customOfflineConfig,
         );
         const cache = disableOffline ? new InMemoryCache() : new OfflineCache(store);
 

--- a/packages/aws-appsync/src/store.js
+++ b/packages/aws-appsync/src/store.js
@@ -12,8 +12,10 @@ import { reducer as commitReducer, offlineEffect, discard } from './link/offline
  * @param {AWSAppSyncClient} client
  * @param {Function} persistCallback 
  * @param {Function} conflictResolver 
+ * @param {Object} customOfflineConfig 
  */
-const newStore = (client, persistCallback = () => null, conflictResolver) => {
+const newStore = (client, persistCallback = () => null, conflictResolver, customOfflineConfig) => {
+    const finalOfflineConfig = Object.assign({}, offlineConfig, customOfflineConfig);
     return createStore(
         combineReducers({
             rehydrated: (state = false, action) => {
@@ -31,7 +33,7 @@ const newStore = (client, persistCallback = () => null, conflictResolver) => {
         compose(
             applyMiddleware(thunk),
             offline({
-                ...offlineConfig,
+                ...finalOfflineConfig,
                 persistCallback,
                 persistOptions: {
                     whitelist: [NORMALIZED_CACHE_KEY, 'offline']


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add the ability to pass custom config to redux-offline

```js
const client = new AWSAppSyncClient({
    url: appSyncConfig.graphqlEndpoint,
    region: appSyncConfig.region,
    auth: {
      type: appSyncConfig.authenticationType,
      apiKey: appSyncConfig.apiKey,
    }
  },
  {},
+ {
+  detectNetwork: () => false,
+});
```

Feedback appreciated.

cc @undefobj @dabit3 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.