### PR TITLE
Support custom persist options

### DIFF
--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -93,6 +93,7 @@ class AWSAppSyncClient extends ApolloClient {
         auth,
         conflictResolver,
         complexObjectsCredentials,
+        persistOptions,
         cacheOptions,
         disableOffline = false
     } = {}, options = {}) {
@@ -106,7 +107,7 @@ class AWSAppSyncClient extends ApolloClient {
 
         let resolveClient;
 
-        const store = disableOffline ? null : createStore(() => this, () => resolveClient(this), conflictResolver);
+        const store = disableOffline ? null : createStore(() => this, () => resolveClient(this), persistOptions, conflictResolver);
         const cache = disableOffline ? (customCache || new InMemoryCache(cacheOptions)) : new OfflineCache(store, cacheOptions);
 
         const waitForRehydrationLink = new ApolloLink((op, forward) => {

--- a/packages/aws-appsync/src/store.js
+++ b/packages/aws-appsync/src/store.js
@@ -9,12 +9,13 @@ import { reducer as cacheReducer, NORMALIZED_CACHE_KEY } from './cache/index';
 import { reducer as commitReducer, offlineEffect, discard } from './link/offline-link';
 
 /**
- * 
+ *
  * @param {() => AWSAppSyncClient} clientGetter
- * @param {Function} persistCallback 
- * @param {Function} conflictResolver 
+ * @param {Function} persistCallback
+ * @param {object} persistOptions
+ * @param {Function} conflictResolver
  */
-const newStore = (clientGetter = () => null, persistCallback = () => null, conflictResolver) => {
+const newStore = (clientGetter = () => null, persistCallback = () => null, persistOptions = {}, conflictResolver) => {
     return createStore(
         combineReducers({
             rehydrated: (state = false, action) => {
@@ -35,7 +36,8 @@ const newStore = (clientGetter = () => null, persistCallback = () => null, confl
                 ...offlineConfig,
                 persistCallback,
                 persistOptions: {
-                    whitelist: [NORMALIZED_CACHE_KEY, 'offline']
+                    whitelist: [NORMALIZED_CACHE_KEY, 'offline'],
+                    ...persistOptions,
                 },
                 effect: (effect, action) => offlineEffect(clientGetter(), effect, action),
                 discard: discard(conflictResolver),


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
I've added support for custom options for `redux-persist`. Most important is that this allows developers to use alternative storage engines, like `localforage` (for IndexedDB). 

List of options: https://github.com/rt2zz/redux-persist/tree/v4#persiststorestore-config-callback
List of supported storage engines: https://github.com/rt2zz/redux-persist#storage-engines

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
