### PR TITLE
Fixing the problem of window not defined with using polyfill

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -24,6 +24,7 @@
     "apollo-link-http": "^1.0.0",
     "aws-sdk": "^2.139.0",
     "graphql": "^0.11.7",
+    "node-window-polyfill": "^1.0.0",
     "paho-client": "^1.0.1",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",

--- a/packages/aws-appsync/src/client.js
+++ b/packages/aws-appsync/src/client.js
@@ -6,6 +6,7 @@
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
+import "node-window-polyfill/register";
 import 'setimmediate';
 import ApolloClient, { ApolloClientOptions, MutationOptions } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';


### PR DESCRIPTION
*Description of changes:*

Fixing the issue with `window` not defined in some environments of node. 
It was tested in aws lambda with node8.10. 
It's a save polyfill so if the `window` is working correctly it's doing nothing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
