### PR TITLE
Preserve original headers (Fixes #119)

### DIFF
--- a/packages/aws-appsync/src/link/auth-link.js
+++ b/packages/aws-appsync/src/link/auth-link.js
@@ -48,6 +48,7 @@ export class AuthLink extends ApolloLink {
 const headerBasedAuth = async ({ header, value } = { header: '', value: '' }, operation, forward) => {
     const origContext = operation.getContext();
     let headers = {
+        ...origContext.headers,
         [USER_AGENT_HEADER]: USER_AGENT,
     };
 
@@ -93,6 +94,7 @@ const iamBasedAuth = async ({ credentials, region, url }, operation, forward) =>
     operation.setContext({
         ...origContext,
         headers: {
+            ...origContext.headers,
             ...headers,
             [USER_AGENT_HEADER]: USER_AGENT,
         },


### PR DESCRIPTION
Fixes #119

*Description of changes:*
When adding authentication headers via the call to `operation.setContext` in `auth-link.js`, any original headers are overwritten.  This change preserves any original headers that were present on the context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
