### PR TITLE
Detect if we should use ssl via the mqtt url

### DIFF
--- a/packages/aws-appsync/src/link/subscription-handshake-link.js
+++ b/packages/aws-appsync/src/link/subscription-handshake-link.js
@@ -167,7 +167,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
 
         return new Promise((resolve, reject) => {
             client.connect({
-                useSSL: true,
+                useSSL: url.indexOf('wss://') === 0,
                 mqttVersion: 3,
                 onSuccess: () => resolve(client),
                 onFailure: reject,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Automatically detect if we should use ssl by inspecting the mqtt url.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

Why is this useful? We're building an emulator for appsync and one of the roadblocks we ran into is the required use of SSL for the mqtt websocket connections. This is obviously great and what we should use in production but for local development (on the emulator) it would be much easier if we can just pass a normal http (ws://) url and have things "just work".

I tested this via our appsync application (both against our emulator and production AWS)