### PR TITLE
Options parameter in AppSyncClient constructor made optional

### DIFF
--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -141,7 +141,7 @@ class AWSAppSyncClient<TCacheShape> extends ApolloClient<TCacheShape> {
         complexObjectsCredentials,
         cacheOptions = {},
         disableOffline = false
-    }: AWSAppSyncClientOptions, options: ApolloClientOptions<InMemoryCache>) {
+    }: AWSAppSyncClientOptions, options?: ApolloClientOptions<InMemoryCache>) {
         const { cache: customCache = undefined, link: customLink = undefined } = options || {};
 
         if (!customLink && (!url || !region || !auth)) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The client instantiation example from the docs will throw a TypeScript error stating that a second parameter is necessary. I've made that second options parameter optional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
