### PR TITLE
Ensure broadcast queries are not disabled unless doIt flag is set

### DIFF
--- a/packages/aws-appsync/src/link/offline-link.ts
+++ b/packages/aws-appsync/src/link/offline-link.ts
@@ -46,6 +46,7 @@ export class OfflineLink extends ApolloLink {
             const { operation: operationType } = getOperationDefinition(operation.query);
             const isMutation = operationType === 'mutation';
             const isQuery = operationType === 'query';
+            const { optimisticResponse, AASContext: { doIt = false } = {} } = operation.getContext();
 
             if (!online && isQuery) {
                 const data = processOfflineQuery(operation, this.store);
@@ -57,8 +58,7 @@ export class OfflineLink extends ApolloLink {
             }
 
             if (isMutation) {
-                const { optimisticResponse, AASContext: { doIt = false } = {} } = operation.getContext();
-
+                
                 if (!doIt) {
                     if (!optimisticResponse) {
                         console.warn('An optimisticResponse was not provided, it is required when using offline capabilities.');
@@ -85,7 +85,9 @@ export class OfflineLink extends ApolloLink {
                         const { [METADATA_KEY]: { snapshot: { cache: cacheSnapshot } } } = this.store.getState();
                         const { cache, AASContext: { client } } = operation.getContext();
 
-                        client.queryManager.broadcastQueries = () => { };
+                        if(doIt) {
+                            client.queryManager.broadcastQueries = () => { };
+                        }
 
                         const silenceBroadcast = cache.silenceBroadcast;
                         cache.silenceBroadcast = true;


### PR DESCRIPTION
Fix for Issue #170

It seems that PR #146 inadvertently caused some code to execute even if the `doIt` flag was not enabled. This caused mutations to fail due to a `undefined` reference of `client`, and also disabling broadcast of queries when it shouldn't.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
