### PR TITLE
fix(typescript): client.mutate - remove JSDoc in favor of TypeScript

### DIFF
--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -186,12 +186,7 @@ class AWSAppSyncClient<TCacheShape> extends ApolloClient<TCacheShape> {
         this._store = store;
     }
 
-    /**
-     *
-     * @param {MutationOptions} options
-     * @returns {Promise<FetchResult>}
-     */
-    async mutate(options) {
+    async mutate(options: MutationOptions<TCacheShape>): Promise<FetchResult> {
         const { update, refetchQueries, context: origContext = {}, ...otherOptions } = options;
         const { AASContext: { doIt = false, ...restAASContext } = {} } = origContext;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
client.mutate - remove JSDoc in favor of TypeScript

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
