### PR TITLE
update authType to authenticationType as is provided by AppSync.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const client = new AWSAppSyncClient({
   url: AppSyncConfig.graphqlEndpoint,
   region: AppSyncConfig.region,
   auth: {
-    type: AppSyncConfig.authType,
+    type: AppSyncConfig.authenticationType,
     apiKey: AppSyncConfig.apiKey,
     jwtToken: async () => token, // Required when you use Cognito UserPools OR OpenID Connect. token object is obtained previously
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix typo in README pointing to wrong key from AppSync file provided by aws for auth type


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
