### PR TITLE
Fixed Rehydrated children type

### DIFF
--- a/packages/aws-appsync-react/src/rehydrated-rn.tsx
+++ b/packages/aws-appsync-react/src/rehydrated-rn.tsx
@@ -1,9 +1,9 @@
 /*!
  * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of 
+ * Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of
  * the License is located at
  *     http://aws.amazon.com/asl/
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 import * as React from "react";
@@ -33,7 +33,7 @@ const styles = StyleSheet.create({
 
 export interface RehydratedProps {
     render?: ((props: { rehydrated: boolean }) => React.ReactNode);
-    children?: React.ReactChildren;
+    children?: React.ReactNode;
     loading?: React.ComponentType<any>;
     style?: any;
 }

--- a/packages/aws-appsync-react/src/rehydrated.tsx
+++ b/packages/aws-appsync-react/src/rehydrated.tsx
@@ -1,9 +1,9 @@
 /*!
  * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of 
+ * Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of
  * the License is located at
  *     http://aws.amazon.com/asl/
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 import * as React from 'react';
@@ -25,7 +25,7 @@ const Rehydrate = (props: RehydrateProps) => (
 
 export interface RehydratedProps {
     render?: ((props: { rehydrated: boolean }) => React.ReactNode);
-    children?: React.ReactChildren;
+    children?: React.ReactNode;
     loading?: React.ComponentType<any>;
 }
 


### PR DESCRIPTION
*Issue #205*

*Description of changes:*

Changes the type of `Rehydrated`'s children from `React.ReactChildren` to `React.ReactNode`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
