### PR TITLE
Implement `isObject` function: check for `null` and `object` type

### DIFF
--- a/packages/aws-appsync/src/helpers/offline.ts
+++ b/packages/aws-appsync/src/helpers/offline.ts
@@ -203,7 +203,7 @@ const findArrayInObject = (obj, path: string[] = []): string[] => {
 };
 
 const getValueByPath = (obj, path: string[]) => {
-    if (!isObject(obj))
+    if (!isObject(obj)) {
         return obj;
     }
 

--- a/packages/aws-appsync/src/helpers/offline.ts
+++ b/packages/aws-appsync/src/helpers/offline.ts
@@ -182,7 +182,7 @@ const findArrayInObject = (obj, path: string[] = []): string[] => {
         return path;
     }
 
-    if (typeof obj !== 'object') {
+    if (!isObject(obj)) {
         return undefined;
     }
 
@@ -203,7 +203,7 @@ const findArrayInObject = (obj, path: string[] = []): string[] => {
 };
 
 const getValueByPath = (obj, path: string[]) => {
-    if (typeof obj !== 'object') {
+    if (!isObject(obj))
         return obj;
     }
 
@@ -229,6 +229,9 @@ const setValueByPath = <T>(obj: T, path: string[] = [], value): T => path.reduce
 }, obj);
 
 const isDocument = (doc) => !!doc && doc.kind === 'Document';
+
+// make sure that the object is of type object and is not null.
+const isObject = (object) => object != null && (typeof object === 'object')
 
 /**
  * Builds a MutationOptions object ready to be used by the ApolloClient to automatically update the cache according to the cacheUpdateQuery 


### PR DESCRIPTION
To avoid keying on null object

*Issue #, if available:*
#210 
*Description of changes:*
- implement `isObject` function
- Replace in `getValueByPath` and `findArrayInObject`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
