### PR TITLE
fix(react-native): Discrepancy in JavaScriptCore iOS vs Android

### DIFF
--- a/packages/aws-appsync/src/link/complex-object-link.ts
+++ b/packages/aws-appsync/src/link/complex-object-link.ts
@@ -37,7 +37,7 @@ export const complexObjectLink = (credentials) => {
 
             const { operation: operationType } = getOperationDefinition(operation.query);
             const isMutation = operationType === 'mutation';
-            const objectsToUpload = isMutation && findInObject(operation.variables);
+            const objectsToUpload = isMutation ? findInObject(operation.variables) : {};
 
             let uploadPromise = Promise.resolve(operation);
 


### PR DESCRIPTION
`Object.keys(false)` was silently failing in android.

*Issue #, if available:*
Fixes #219 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
