### PR TITLE
Use HttpLink from initial config for subscriptions

### DIFF
--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -45,7 +45,7 @@ export const createSubscriptionHandshakeLink = (url, resultsFetcherLink = new Ht
             return isSubscription;
         },
         ApolloLink.from([
-            new NonTerminatingHttpLink('subsInfo', { uri: url }),
+            new NonTerminatingHttpLink('subsInfo', resultsFetcherLink),
             new SubscriptionHandshakeLink('subsInfo'),
         ]),
         resultsFetcherLink,

--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -21,7 +21,7 @@ import {
     replaceUsingMap,
     saveServerId,
     AuthLink,
-    NonTerminatingHttpLink,
+    NonTerminatingLink,
     SubscriptionHandshakeLink,
     ComplexObjectLink,
     AUTH_TYPE
@@ -45,7 +45,7 @@ export const createSubscriptionHandshakeLink = (url, resultsFetcherLink = new Ht
             return isSubscription;
         },
         ApolloLink.from([
-            new NonTerminatingHttpLink('subsInfo', resultsFetcherLink),
+            new NonTerminatingLink('subsInfo', { link: resultsFetcherLink }),
             new SubscriptionHandshakeLink('subsInfo'),
         ]),
         resultsFetcherLink,

--- a/packages/aws-appsync/src/link/index.ts
+++ b/packages/aws-appsync/src/link/index.ts
@@ -10,5 +10,6 @@ export { AuthLink, AUTH_TYPE } from './auth-link';
 export { OfflineLink, saveSnapshot, replaceUsingMap, saveServerId } from './offline-link';
 export { SubscriptionHandshakeLink } from "./subscription-handshake-link";
 export { NonTerminatingHttpLink } from "./non-terminating-http-link";
+export { NonTerminatingLink } from "./non-terminating-link";
 export { ComplexObjectLink } from "./complex-object-link";
 export { Signer } from "./signer";

--- a/packages/aws-appsync/src/link/non-terminating-http-link.ts
+++ b/packages/aws-appsync/src/link/non-terminating-http-link.ts
@@ -1,41 +1,16 @@
 /*!
- * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of 
  * the License is located at
  *     http://aws.amazon.com/asl/
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
  * KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-import { ApolloLink, Observable } from 'apollo-link';
-import { setContext } from 'apollo-link-context';
-import { createHttpLink } from 'apollo-link-http';
-import { ExecutionResult } from 'graphql';
+import { createHttpLink, FetchOptions } from 'apollo-link-http';
+import { NonTerminatingLink } from './non-terminating-link';
 
-export class NonTerminatingHttpLink extends ApolloLink {
-
-    contextKey;
-    /** @type {ApolloLink} */
-    link;
-
-    constructor(contextKey, options) {
-        super();
-        this.contextKey = contextKey;
-        this.link = options.resultsFetcherLink;
-    }
-
-    request(operation, forward) {
-        return setContext(async (request, prevContext) => {
-            const result = await new Promise((resolve, reject) => {
-                this.link.request(operation).subscribe({
-                    next: resolve,
-                    error: reject,
-                });
-            });
-
-            return {
-                ...prevContext,
-                [this.contextKey]: result,
-            }
-        }).request(operation, forward);
+export class NonTerminatingHttpLink extends NonTerminatingLink {
+    constructor(contextKey: string, options: FetchOptions) {
+        super(contextKey, { link: createHttpLink(options) });
     }
 }

--- a/packages/aws-appsync/src/link/non-terminating-http-link.ts
+++ b/packages/aws-appsync/src/link/non-terminating-http-link.ts
@@ -20,7 +20,7 @@ export class NonTerminatingHttpLink extends ApolloLink {
     constructor(contextKey, options) {
         super();
         this.contextKey = contextKey;
-        this.link = createHttpLink(options);
+        this.link = options.resultsFetcherLink;
     }
 
     request(operation, forward) {

--- a/packages/aws-appsync/src/link/non-terminating-link.ts
+++ b/packages/aws-appsync/src/link/non-terminating-link.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of 
+ * the License is located at
+ *     http://aws.amazon.com/asl/
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+ * KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+import { ApolloLink, Observable } from 'apollo-link';
+import { isTerminating } from 'apollo-link/lib/linkUtils';
+import { setContext } from 'apollo-link-context';
+import { ExecutionResult } from 'graphql';
+
+export class NonTerminatingLink extends ApolloLink {
+
+    private contextKey: string;
+    private link: ApolloLink;
+
+    constructor(contextKey: string, { link }: { link: ApolloLink }) {
+        super();
+
+        if (!isTerminating(link)) {
+            throw new Error('The link provided is not a terminating link');
+        }
+
+        this.contextKey = contextKey;
+        this.link = link;
+    }
+
+    request(operation, forward) {
+        return setContext(async (request, prevContext) => {
+            const result = await new Promise((resolve, reject) => {
+                this.link.request(operation).subscribe({
+                    next: resolve,
+                    error: reject,
+                });
+            });
+
+            return {
+                ...prevContext,
+                [this.contextKey]: result,
+            }
+        }).request(operation, forward);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For starters, thank you so much for this library! It's helping us tremendously 😄 

My situation is:

I am using a lambda resolver on my subscription fields, in order to ensure users only subscribe to events they are authorised to.
My lambda resolver is using it's own auth middleware which reads a token passed in the authorisation header.
Setting this header has to be done on the clients, to do this I am using this code, where it grabs it from my store:

```js
new AWSAppSyncClient(AppSyncConfig, {
  link: createAppSyncLink({
    ...AppSyncConfig,
    resultsFetcherLink: ApolloLink.from([
      setContext((request, previousContext) => {
        const { accessToken } = store.getState()
        if (accessToken) {
          return ({
            headers: {
              ...previousContext.headers,
              'Authorization': `Bearer ${accessToken}`,
            }
          })
        }

        return ({
          headers: {
            ...previousContext.headers,
          }
        })
      }),
      createHttpLink({
        uri: AppSyncConfig.url
      })
    ])
  })
})
```
This was working beautifully until I started trying to use subscriptions, then I found my header wasn't being sent through.

I then found this split when the client was handling the initial resolve for the subscription, and found passing the existing `resultsFetcherLink` through to `NonTerminatingHttpLink` instead of just the url and having it create a new `HTTPLink` worked great.

I don't know if `NonTerminatingHttpLink` was creating it's own `HTTPLink` for a reason but this seems to work perfectly for me. I'd appreciate others testing this against their own setups before it's merged!

Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
