### PR TITLE
fix(typescript): Make all fields in ApolloClientOptions optional

### DIFF
--- a/packages/aws-appsync-react/package.json
+++ b/packages/aws-appsync-react/package.json
@@ -30,7 +30,7 @@
     "react": "^16.1.1",
     "react-apollo": "^2.1.9",
     "react-native": "^0.50.3",
-    "typescript": "^2.6.1"
+    "typescript": "^3.0.1"
   },
   "react-native": {
     "./lib/rehydrated": "./lib/rehydrated-rn"

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -56,6 +56,6 @@
     "graphql-tag": "^2.9.2",
     "jest": "^23.4.2",
     "ts-jest": "^23.0.1",
-    "typescript": "^2.5.3"
+    "typescript": "^3.0.1"
   }
 }

--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -129,11 +129,6 @@ class AWSAppSyncClient<TCacheShape> extends ApolloClient<TCacheShape> {
         }
     }
 
-    /**
-     *
-     * @param {object} appSyncOptions
-     * @param {ApolloClientOptions<InMemoryCache>} options
-     */
     constructor({
         url,
         region,
@@ -142,7 +137,7 @@ class AWSAppSyncClient<TCacheShape> extends ApolloClient<TCacheShape> {
         complexObjectsCredentials,
         cacheOptions = {},
         disableOffline = false
-    }: AWSAppSyncClientOptions, options?: ApolloClientOptions<InMemoryCache>) {
+    }: AWSAppSyncClientOptions, options?: Partial<ApolloClientOptions<TCacheShape>>) {
         const { cache: customCache = undefined, link: customLink = undefined } = options || {};
 
         if (!customLink && (!url || !region || !auth)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5928,9 +5928,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.5.3, typescript@^2.6.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #220 
Closes #221 

*Description of changes:*
- Upgrade typescript
- Make all fields in ApolloClientOptions optional

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
