### PR TITLE
Object.keys(string) Android Problem

### DIFF
--- a/packages/aws-appsync/src/link/offline-link.ts
+++ b/packages/aws-appsync/src/link/offline-link.ts
@@ -382,7 +382,7 @@ export const discard = (fn = (obj: ConflictResolutionInfo) => 'DISCARD') => (err
 //#region utils
 
 export const replaceUsingMap = (obj, map = {}) => {
-    if (!obj || !map) {
+    if (!obj || !map || typeof obj !== 'object') {
         return obj;
     }
 
@@ -412,7 +412,7 @@ export const replaceUsingMap = (obj, map = {}) => {
 };
 
 const getIds = (dataIdFromObject, obj, path = '', acc = {}) => {
-    if (!obj) {
+    if (!obj || !(typeof obj === 'object')) {
         return acc;
     }
 


### PR DESCRIPTION
Related: https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/222
Related: https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/219

*Issue #, if available:*

https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/219

*Description of changes:*

Check if obj is of type `object`.

iOS and Android treat `Object.keys('123')'` differently, apparently...
iOS yields: `["0", "1", "2"]` (just like Chrome)
Android eventually blow up, with "Requested keys of a value that is not an object."

Happens with mutations that contain arrays, like:
```
...
    ids: ["abc-123", "def-456"]
...
```

I am assuming/understanding that `strings` in arrays should not be recursively treated here.

Hence, also the iOS way of getting the keys in the string is wrong. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
