### PR TITLE
onConnectionLost implementation for subscriptions

### DIFF
--- a/packages/aws-appsync/src/link/subscription-handshake-link.ts
+++ b/packages/aws-appsync/src/link/subscription-handshake-link.ts
@@ -167,6 +167,9 @@ export class SubscriptionHandshakeLink extends ApolloLink {
             // console.log(`Doing setup for ${topics.length} topics`, topics);
 
             const subPromises = topics.map(topic => new Promise((resolve, reject) => {
+                (client as any).onConnectionLost = function (e) {
+                    this.onError(topic, e);
+                };
                 (client as any).subscribe(topic, {
                     onSuccess: () => {
                         if (!this.topicObserver.has(topic)) {
@@ -179,7 +182,8 @@ export class SubscriptionHandshakeLink extends ApolloLink {
                 });
             }));
 
-            return Promise.all(subPromises).then(([...topics]: any[]) => {
+            return Promise.all(
+            ).then(([...topics]: any[]) => {
                 // console.log('All topics subscribed', topics);
 
                 this.clientTopics.set(client, topics);
@@ -201,4 +205,13 @@ export class SubscriptionHandshakeLink extends ApolloLink {
             // console.error(err);
         }
     }
+    
+    onError = (topic, error) => {
+        const observer = this.topicObserver.get(topic);
+        try {
+            observer.error(error);
+        } catch (err) {
+            // console.error(err);
+        }
+    };
 }


### PR DESCRIPTION
making sure we send onError status messages for subscriptions when the connection has been lost

*Issue #, if available:*
#230 #132 
*Description of changes:*
used Paho client onConnectionLost listener to send the lost connection status to error listener of subscriptions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
