### PR TITLE
fix: fixing aws-sdk version to 2.329.0

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -26,7 +26,7 @@
     "apollo-link-context": "^1.0.0",
     "apollo-link-http": "^1.0.0",
     "apollo-link-retry": "^2.2.4",
-    "aws-sdk": "^2.139.0",
+    "aws-sdk": "2.329.0",
     "graphql": "^0.11.7",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fixing aws-sdk version to be the same as aws-amplify/core

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
