### PR TITLE
fix(subscriptions): Do not retry mqtt disconnections

### DIFF
--- a/packages/aws-appsync/src/link/subscription-handshake-link.ts
+++ b/packages/aws-appsync/src/link/subscription-handshake-link.ts
@@ -13,6 +13,7 @@ import * as Paho from '../vendor/paho-mqtt';
 import { ApolloError } from "apollo-client";
 import { FieldNode } from "graphql";
 import { getMainDefinition } from "apollo-utilities";
+import { PERMANENT_ERROR_KEY } from "./retry-link";
 
 const logger = rootLogger.extend('subscriptions');
 const mqttLogger = logger.extend('mqtt');
@@ -66,11 +67,11 @@ export class SubscriptionHandshakeLink extends ApolloLink {
             } = { subscription: { newSubscriptions: {}, mqttConnections: [] } },
             errors = [],
         }: {
-                extensions?: {
-                    subscription: SubscriptionExtension
-                },
-                errors: any[]
-            } = subsInfo;
+            extensions?: {
+                subscription: SubscriptionExtension
+            },
+            errors: any[]
+        } = subsInfo;
 
         if (errors.length) {
             return new Observable(observer => {
@@ -170,7 +171,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
             if (errorCode !== 0) {
                 topics.forEach(t => {
                     if (this.topicObservers.has(t)) {
-                        this.topicObservers.get(t).forEach(observer => observer.error(args));
+                        this.topicObservers.get(t).forEach(observer => observer.error({ ...args, [PERMANENT_ERROR_KEY]: true }));
                     }
                 });
             }


### PR DESCRIPTION
- If auto-reconnect when coming back online is needed, users should use  `client.sync` (deltaSync) instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
