### PR TITLE
preserve order of elements in update cache operation type

### DIFF
--- a/packages/aws-appsync/src/helpers/offline.ts
+++ b/packages/aws-appsync/src/helpers/offline.ts
@@ -152,8 +152,10 @@ export const getUpdater = <T>(opType: CacheOperationTypes, idField = 'id'): (arr
 
     switch (opType) {
         case CacheOperationTypes.ADD:
-        case CacheOperationTypes.UPDATE:
             updater = (arr, newItem) => !newItem ? [...arr] : [...arr.filter(item => item[idField] !== newItem[idField]), newItem];
+            break;
+        case CacheOperationTypes.UPDATE:
+            updater = (arr, newItem) => !newItem ? [...arr] : arr.map(item => item[idField] === newItem[idField] ? newItem : item);
             break;
         case CacheOperationTypes.REMOVE:
             updater = (arr, newItem) => !newItem ? [] : arr.filter(item => item[idField] !== newItem[idField]);


### PR DESCRIPTION
*Issue #, if available:*
- The updater function in [offline.ts](https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/packages/aws-appsync/src/helpers/offline.ts#L155) on **update/modify of an item filters it from the list and then appends the updated/modified item to the last**. 
- When displaying the list of items, this causes the following unexpected behaviours
  - The item jumps from its original position to the last of the list.
  - When the entire list is refetched/ when the page reloads the item comes back to its original position

*Description of changes:*
- This PR fixes it by preserving the order in the updater function, by doing a map and replacing the updated/modified item in its original position.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
