### PR TITLE
Guard against errors: null response in subscription handshake

### DIFF
--- a/packages/aws-appsync/src/link/subscription-handshake-link.ts
+++ b/packages/aws-appsync/src/link/subscription-handshake-link.ts
@@ -72,7 +72,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
                 errors: any[]
             } = subsInfo;
 
-        if (errors.length) {
+        if (errors && errors.length) {
             return new Observable(observer => {
                 observer.error(new ApolloError({
                     errorMessage: 'Error during subscription handshake',


### PR DESCRIPTION
During the subscription handshake there is an edge case where the server may return a valid GraphQL response:

```
{
      extensions: { ... }
      data: null,
      errors: null,
}
```

Returning  `errors: null` causing an `Uncaught TypeError: Cannot read property 'length' of null` exception within the SDK.

This change is a QoL change for developers who are building tools around AppSync-SDK such as [appsync-emulator-serverless](https://github.com/ConduitVC/aws-utils/tree/master/packages/appsync-emulator-serverless) who may expect AppSync-SDK to handle this type of response

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.