### PR TITLE
Remove temporary variables (starting with '@@') before signing

### DIFF
--- a/packages/aws-appsync/src/link/auth-link.ts
+++ b/packages/aws-appsync/src/link/auth-link.ts
@@ -36,7 +36,7 @@ export class AuthLink extends ApolloLink {
     private link: ApolloLink;
 
     /**
-     * 
+     *
      * @param {*} options
      */
     constructor(options) {
@@ -167,7 +167,7 @@ export const authLink = ({ url, region, auth: { type = AUTH_TYPE.NONE, credentia
 const formatAsRequest = ({ operationName, variables, query }, options) => {
     const body = {
         operationName,
-        variables,
+        variables: removeTemporaryVariables(variables),
         query: print(query)
     };
 
@@ -182,3 +182,15 @@ const formatAsRequest = ({ operationName, variables, query }, options) => {
         },
     };
 }
+
+/**
+ * Removes all temporary variables (starting with '@@') so that the signature matches the final request.
+ */
+const removeTemporaryVariables = (variables: any) =>
+  Object.keys(variables)
+    .filter(key => !key.startsWith("@@"))
+    .reduce((acc, key) => {
+      acc[key] = variables[key];
+      return acc;
+    }, {});
+


### PR DESCRIPTION
This fixes an InvalidSignatureExceptions that occurs when using iamBasedAuthentication and the '@@controlEvents' variable in subscriptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
