### PR TITLE
Make effect delay and network detection configurables

### DIFF
--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -24,7 +24,7 @@ import {
     ComplexObjectLink,
     AUTH_TYPE
 } from './link';
-import { createStore } from './store';
+import { createStore, OfflineStatusChangeCallbackCreator } from './store';
 import { ApolloCache } from 'apollo-cache';
 import { AuthOptions } from './link/auth-link';
 import { Credentials, CredentialsOptions } from 'aws-sdk/lib/credentials';
@@ -77,6 +77,7 @@ export const createAppSyncLink = ({
     complexObjectsCredentials,
     resultsFetcherLink = createHttpLink({ uri: url }),
     conflictResolver,
+    getDelay
 }: {
         url: string,
         region: string,
@@ -84,6 +85,7 @@ export const createAppSyncLink = ({
         complexObjectsCredentials: CredentialsGetter,
         resultsFetcherLink?: ApolloLink,
         conflictResolver?: ConflictResolver,
+        getDelay?: (retries: number)=> number
     }) => {
     const link = ApolloLink.from([
         createLinkWithStore((store) => new OfflineLink(store)),
@@ -92,7 +94,7 @@ export const createAppSyncLink = ({
         createRetryLink(ApolloLink.from([
             createAuthLink({ url, region, auth }),
             createSubscriptionHandshakeLink(url, resultsFetcherLink)
-        ]))
+        ]), getDelay)
     ].filter(Boolean));
 
     return link;
@@ -141,6 +143,8 @@ export interface OfflineConfig {
     storage?: any,
     callback?: OfflineCallback,
     storeCacheRootMutation?: boolean,
+    detectNetwork?: OfflineStatusChangeCallbackCreator,
+    getDelay?: (retries:number)=>number
 };
 
 // TODO: type defs
@@ -180,6 +184,8 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
             storage = undefined,
             callback = () => { },
             storeCacheRootMutation = false,
+            detectNetwork = undefined,
+            getDelay=undefined
         } = {},
     }: AWSAppSyncClientOptions, options?: Partial<ApolloClientOptions<TCacheShape>>) {
         const { cache: customCache = undefined, link: customLink = undefined } = options || {};
@@ -197,7 +203,9 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
             () => this, () => { resolveClient(this); },
             dataIdFromObject,
             storage,
-            callback
+            callback,
+            detectNetwork,
+            getDelay
         );
         const cache: ApolloCache<any> = disableOffline
             ? (customCache || new InMemoryCache(cacheOptions))
@@ -218,7 +226,7 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
                 };
             });
         });
-        const link = waitForRehydrationLink.concat(customLink || createAppSyncLink({ url, region, auth, complexObjectsCredentials, conflictResolver }));
+        const link = waitForRehydrationLink.concat(customLink || createAppSyncLink({ url, region, auth, complexObjectsCredentials, conflictResolver, getDelay }));
 
         const newOptions = {
             ...options,

--- a/packages/aws-appsync/src/link/retry-link.ts
+++ b/packages/aws-appsync/src/link/retry-link.ts
@@ -15,18 +15,18 @@ const BASE_TIME_MS = 100;
 const JITTER_FACTOR = 100;
 const MAX_DELAY_MS = 5 * 60 * 1000;
 
-const getDelay = count => ((2 ** count) * BASE_TIME_MS) + (JITTER_FACTOR * Math.random());
+const getDefaultDelay = count => ((2 ** count) * BASE_TIME_MS) + (JITTER_FACTOR * Math.random());
 
 export const SKIP_RETRY_KEY = '@@skipRetry';
 export const PERMANENT_ERROR_KEY = typeof Symbol !== 'undefined' ? Symbol('permanentError') : '@@permanentError';
 
-export const getEffectDelay = (_action: OfflineAction, retries: number) => {
+export const getEffectDelay = (getDelay:(retries:number) => number=getDefaultDelay) => (_action: OfflineAction, retries: number) => {
     const delay = getDelay(retries);
 
     return delay <= MAX_DELAY_MS ? delay : null;
 };
 
-export const createRetryLink = (origLink: ApolloLink) => {
+export const createRetryLink = (origLink: ApolloLink, getDelay:(retries:number) => number=getDefaultDelay) => {
     let delay;
 
     const retryLink = new RetryLink({

--- a/packages/aws-appsync/src/store.ts
+++ b/packages/aws-appsync/src/store.ts
@@ -22,7 +22,7 @@ import { OfflineAction, NetInfo, NetworkCallback } from '@redux-offline/redux-of
 import { offlineEffectConfig as deltaSyncConfig } from "./deltaSync";
 import { Observable } from 'apollo-link';
 
-const { detectNetwork } = defaultOfflineConfig;
+const { detectNetwork : defaultDetectNetwork } = defaultOfflineConfig;
 
 const logger = rootLogger.extend('store');
 
@@ -32,6 +32,8 @@ const newStore = <TCacheShape extends NormalizedCacheObject>(
     dataIdFromObject: (obj) => string | null,
     storage: any,
     callback: OfflineCallback = () => { },
+    detectNetwork: OfflineStatusChangeCallbackCreator = defaultDetectNetwork,
+    getDelay?: (retries:number) => number
 ): Store<any> => {
     logger('Creating store');
 
@@ -53,7 +55,7 @@ const newStore = <TCacheShape extends NormalizedCacheObject>(
             applyMiddleware(thunk),
             offline({
                 ...defaultOfflineConfig,
-                retry: getEffectDelay,
+                retry: getEffectDelay(getDelay),
                 persistCallback: () => {
                     logger('Storage ready');
 


### PR DESCRIPTION
This pull request helps us to fix issue #375



*Description of changes:*

The goal is to make configurable the delay between retries and how network is detected.