### PR TITLE
add s3 ACL in parameter to allow different file permissions

### DIFF
--- a/packages/aws-appsync/src/link/complex-object-link-uploader.ts
+++ b/packages/aws-appsync/src/link/complex-object-link-uploader.ts
@@ -15,6 +15,7 @@ export default (fileField, { credentials }) => {
         region,
         mimeType: ContentType,
         localUri: Body,
+        acl: ACL,
     } = fileField;
 
     const s3 = new S3({
@@ -27,5 +28,6 @@ export default (fileField, { credentials }) => {
         Key,
         Body,
         ContentType,
+        ACL,
     }).promise();
 };

--- a/packages/aws-appsync/src/link/complex-object-link.ts
+++ b/packages/aws-appsync/src/link/complex-object-link.ts
@@ -86,6 +86,7 @@ const complexObjectFields = [
     { name: 'key', type: 'string' },
     { name: 'region', type: 'string' },
     { name: 'mimeType', type: 'string' },
+    { name: 'acl', type: 'string' },
     { name: 'localUri', type: ['object', 'string'] },
 ];
 const findInObject = obj => {
@@ -109,6 +110,7 @@ const findInObject = obj => {
         if (testFn(obj)) {
             acc[path] = { ...obj };
             delete obj.mimeType;
+            delete obj.acl;
             delete obj.localUri;
         }
 


### PR DESCRIPTION
S3 Upload facility through AppSync is missing the key ACL parameter to pass permissions. Hence any uploads which are intended to be `public-read` or take any other permission do not work, and the default private file mode is applied. 

The changes take the ACL parameter defaulting to private and include this in the S3 request giving more control to the end user.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
