### PR TITLE
Update offline.ts

### DIFF
--- a/packages/aws-appsync/src/helpers/offline.ts
+++ b/packages/aws-appsync/src/helpers/offline.ts
@@ -331,7 +331,7 @@ const buildMutation = <T = OperationVariables>(
     return {
         mutation,
         variables: hasInputType
-            ? { input: { ...(useVersioning && { [versionFieldName]: version }), ...variables.input } }
+            ? { input: { ...(useVersioning ? { [versionFieldName]: version } : {}), ...variables.input } }
             : { version, expectedVersion: version, ...variables },
         optimisticResponse: typename ? {
             __typename: "Mutation",


### PR DESCRIPTION
Issue #406 

Compiled code generates this offline.js:266
```
 { input: __assign({}, (useVersioning && (_a = {}, _a[versionFieldName] = version, _a)), variables.input) }
```
Which throws an error in development react-native environments. This fixes that.