### PR TITLE
Update keys from aws-exports.js

### DIFF
--- a/tutorials/react-offline-realtime-todos/README.md
+++ b/tutorials/react-offline-realtime-todos/README.md
@@ -79,11 +79,11 @@ Replace everything __after__ the definition of the `<App />` component with the 
 
 ```jsx
 const client = new AWSAppSyncClient({
-  url: awsmobile.graphqlEndpoint,
-  region: awsmobile.region,
+  url: awsmobile.aws_appsync_graphqlEndpoint,
+  region: awsmobile.aws_appsync_region,
   auth: {
-    type: awsmobile.authenticationType,
-    apiKey: awsmobile.apiKey
+    type: awsmobile.aws_appsync_authenticationType,
+    apiKey: awsmobile.aws_appsync_apiKey
   }
 })
 


### PR DESCRIPTION
It seems like the keys `aws-exports.js` have changed since writing the tutorial.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
