### PR TITLE
Allow `loading` prop on `Rehydrated` to accept `null` values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 *.tgz
 lerna-debug.log
 .npmrc
+.idea

--- a/packages/aws-appsync-react/README.md
+++ b/packages/aws-appsync-react/README.md
@@ -1,1 +1,51 @@
 # aws-appsync-react
+
+This package provides the following helpers which are needed when working with the SDK on a React project.
+
+- `Rehydrated`
+- `graphqlMutation`
+
+----
+## `Rehydrated`
+
+A React component that you need to wrap your app with, when working with Apollo, React & a custom client created with `aws-appsync`. It makes sure
+to wait for a client hydration in an offline environment.
+
+### Import
+```
+import { Rehydrated } from 'aws-appsync-react'
+```
+
+### Props
+
+| Prop name     | Required      | Details |
+| ------------- |:-------------:| :-------|
+| children      | false         | The React Element(s) to show when the client is fully hydrated |
+| loading       | false         | The React Element to show while the client is hydrating. Defaults to the text element `Loading...` |
+| render        | false         | A render-props function that has a single object parameter containing a boolean `rehydrated` and should return a React node. It's signature is: `({ rehydrated: boolean }) => React.ReactNode` |
+
+ Although the props `children` and `render` are mutually exclusive, **at least** one of them should be defined.
+
+
+### Example
+```
+import { ApolloProvider } from 'react-apollo';
+import { Rehydrated } from 'aws-appsync-react'; 
+import App from './App';
+
+const client = /* ... */
+
+const WithProvider = () => (
+  <ApolloProvider client={client}>
+    <Rehydrated>
+      <App />
+    </Rehydrated>
+  </ApolloProvider>
+)
+
+export default WithProvider
+```
+
+## `graphqlMutation`
+
+Full documentation for this helper can be found in the [Offline Helpers API page](https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/OFFLINE_HELPERS.md).

--- a/packages/aws-appsync-react/src/rehydrated-rn.tsx
+++ b/packages/aws-appsync-react/src/rehydrated-rn.tsx
@@ -71,7 +71,7 @@ export default class Rehydrated extends React.Component<RehydratedProps, Rehydra
         if (render) return render({ rehydrated });
 
         if (children) {
-            if (loading) return rehydrated ? children : loading;
+            if (loading !== undefined) return rehydrated ? children : loading;
 
             return (
                 <Rehydrate rehydrated={rehydrated} style={style} >

--- a/packages/aws-appsync-react/src/rehydrated.tsx
+++ b/packages/aws-appsync-react/src/rehydrated.tsx
@@ -59,7 +59,7 @@ export default class Rehydrated extends React.Component<RehydratedProps, Rehydra
         if (render) return render({ rehydrated });
 
         if (children) {
-            if (loading) return rehydrated ? children : loading;
+            if (loading !== undefined) return rehydrated ? children : loading;
 
             return (
                 <Rehydrate rehydrated={rehydrated}>


### PR DESCRIPTION
*Issue #, if available:*
#422 

*Description of changes:*
This PR simply checks `loading` against an `undefined` value, instead of a *falsy* one. The PR also updated the README of the subrepo in order to document the props that the `Rehydrated` component accepts  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
