### PR TITLE
Fix: TypeError: Cannot read property 'reduce' of undefined

### DIFF
--- a/packages/aws-appsync/src/helpers/offline.ts
+++ b/packages/aws-appsync/src/helpers/offline.ts
@@ -212,7 +212,7 @@ const findArrayInObject = (obj, path: string[] = []): string[] => {
     return result;
 };
 
-const getValueByPath = (obj, path: string[]) => {
+const getValueByPath = (obj, path: string[] = []) => {
     if (!isObject(obj)) {
         return obj;
     }


### PR DESCRIPTION
This change should resolve #421 

Passing an undefined variable to the `path` parameter of [getValueByPath](https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/aws-appsync%401.8.1/packages/aws-appsync/src/helpers/offline.ts#L215) results in an error. This change fixes that issue by setting the default value of `path` to be an empty array.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
