### PR TITLE
Update dependencies to support RN 0.60

### DIFF
--- a/packages/aws-appsync-react/package.json
+++ b/packages/aws-appsync-react/package.json
@@ -31,6 +31,7 @@
     "react": "^16.1.1",
     "react-apollo": "^2.1.9",
     "react-native": "^0.50.3",
+    "@react-native-community/netinfo": "^4.1.3",
     "typescript": "^3.0.1"
   },
   "react-native": {

--- a/packages/aws-appsync-react/package.json
+++ b/packages/aws-appsync-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-appsync-react",
-  "version": "1.2.9",
+  "version": "1.2.10-alpha.0",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "description": "AWS Mobile AppSync SDK for JavaScript - React and React Native components",
@@ -25,13 +25,13 @@
     "react-apollo": "2.x"
   },
   "devDependencies": {
+    "@react-native-community/netinfo": "^4.1.3",
     "@types/graphql": "0.12.4",
     "@types/react": "^16.0.25",
-    "aws-appsync": "^1.8.1",
+    "aws-appsync": "^1.8.2-alpha.0",
     "react": "^16.1.1",
     "react-apollo": "^2.1.9",
     "react-native": "^0.50.3",
-    "@react-native-community/netinfo": "^4.1.3",
     "typescript": "^3.0.1"
   },
   "react-native": {

--- a/packages/aws-appsync-react/src/rehydrated-rn.tsx
+++ b/packages/aws-appsync-react/src/rehydrated-rn.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as React from "react";
-import { View, Text, StyleSheet, NetInfo, ViewPropTypes } from "react-native";
+import { View, Text, StyleSheet, ViewPropTypes } from "react-native";
+import NetInfo from '@react-native-community/netinfo';
 import * as PropTypes from 'prop-types';
 
 import AWSAppSyncClient from 'aws-appsync';

--- a/packages/aws-appsync-react/src/rehydrated-rn.tsx
+++ b/packages/aws-appsync-react/src/rehydrated-rn.tsx
@@ -56,7 +56,7 @@ export default class Rehydrated extends React.Component<RehydratedProps, Rehydra
         };
     }
 
-    async componentWillMount() {
+    async componentDidMount() {
         await this.context.client.hydrated();
         await NetInfo.isConnected.fetch();
 

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -19,7 +19,7 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "@redux-offline/redux-offline": "2.2.1",
+    "@redux-offline/redux-offline": "2.5.2-native.0",
     "apollo-cache-inmemory": "1.3.10",
     "apollo-client": "2.4.6",
     "apollo-link": "1.2.3",

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-appsync",
-  "version": "1.8.1",
+  "version": "1.8.2-alpha.0",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "description": "AWS Mobile AppSync SDK for JavaScript",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
@@ -282,12 +289,18 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@redux-offline/redux-offline@2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@redux-offline/redux-offline/-/redux-offline-2.2.1.tgz#4e7622da0b37bb90b5c713b1db50863f81b1038b"
+"@react-native-community/netinfo@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-4.1.3.tgz#77571619eb90ff59777a85a913fc30acd30b6020"
+  integrity sha512-c9ppXNFpKkXiKFJhik9Lzw62dosm+cAIvHl6OOGXp2D+1GlliIP+nMMtNapdppPoilRc33f4/GosqnL70viH9Q==
+
+"@redux-offline/redux-offline@2.5.2-native.0":
+  version "2.5.2-native.0"
+  resolved "https://registry.yarnpkg.com/@redux-offline/redux-offline/-/redux-offline-2.5.2-native.0.tgz#e8c3c65038d20df13389a88eb6f4de4248c59cf4"
+  integrity sha512-ZRH1E0oz9VAnfBZJsyH8O2D3tjQOd0Yz/piPmRsbE1wuoUb+eVM9SZNQetIdJvqmiNs1n3VDfcEeADEbT2dhyg==
   dependencies:
-    babel-runtime "^6.26.0"
-    redux-persist "^4.5.0"
+    "@babel/runtime" "^7.5.5"
+    redux-persist "^4.6.0"
 
 "@types/async@2.0.50":
   version "2.0.50"
@@ -739,9 +752,10 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
-aws-sdk@2.329.0:
-  version "2.329.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.329.0.tgz#616da7ca5e1909e53333148694990e068272150f"
+aws-sdk@2.472.0:
+  version "2.472.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.472.0.tgz#0da7062299125a85fdea5786d13019d80aac8ee4"
+  integrity sha512-uFatrjfMSwC34VxdG9ollX6K61e+iaoE5ZHQ/OKeSoWx9HXs3AwJqIS90iBLEhaAm2WoTMFYAv0irMC8eMCu3g==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -750,7 +764,7 @@ aws-sdk@2.329.0:
     querystring "0.2.0"
     sax "1.2.1"
     url "0.10.3"
-    uuid "3.1.0"
+    uuid "3.3.2"
     xml2js "0.4.19"
 
 aws-sign2@~0.7.0:
@@ -5535,9 +5549,10 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
-redux-persist@^4.5.0:
+redux-persist@^4.6.0:
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.10.2.tgz#8efdb16cfe882c521a78a6d0bfdfef2437f49f96"
+  integrity sha512-U+e0ieMGC69Zr72929iJW40dEld7Mflh6mu0eJtVMLGfMq/aJqjxUM1hzyUWMR1VUyAEEdPHuQmeq5ti9krIgg==
   dependencies:
     json-stringify-safe "^5.0.1"
     lodash "^4.17.4"
@@ -5563,6 +5578,11 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-runtime@^0.9.5:
   version "0.9.6"
@@ -6579,11 +6599,7 @@ uuid@3.0.1:
   version "3.0.1"
   resolved "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-uuid@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-uuid@3.x, uuid@^3.0.1, uuid@^3.3.2:
+uuid@3.3.2, uuid@3.x, uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 


### PR DESCRIPTION
*Issue #, if available: Error on` React-Native` >= 0.60*

> Cannot read property 'getConnectionInfo' of undefined

*Description of changes:*
Update dependency to fix error due to RN removing `NetInfo` from core packages


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
