### PR TITLE
Fixing apollo client version

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@redux-offline/redux-offline": "2.2.1",
     "apollo-cache-inmemory": "1.3.10",
-    "apollo-client": "2.4.6",
+    "apollo-client": "^2.6.3",
     "apollo-link": "1.2.3",
     "apollo-link-context": "1.0.9",
     "apollo-link-http": "1.3.1",


### PR DESCRIPTION
*Issue #, if available:*
Fixes issue #450
*Description of changes:*
Updates `package.json` for `aws-appsync` to reference the current version of `apollo-client`. Enables compatibility with react-apollo 3, including hooks! 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
