### PR TITLE
Update aws-sdk to be the same as amplify

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -26,7 +26,7 @@
     "apollo-link-context": "1.0.9",
     "apollo-link-http": "1.3.1",
     "apollo-link-retry": "2.2.5",
-    "aws-sdk": "2.472.0",
+    "aws-sdk": "2.518.0",
     "debug": "2.6.9",
     "graphql": "0.13.0",
     "redux": "^3.7.2",


### PR DESCRIPTION
*Issue #, if available:*
Fixes: #439 
*Description of changes:*
Update aws-sdk version to the same as aws-amplify

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
