### PR TITLE
Adding setup instructions for React Native 0.60

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,15 @@ If you are using React Native `0.60` and above, you also need to install `@react
 
 ```
 npm install --save @react-native-community/netinfo
-cd ios && pod install && cd .. # iOS needs this extra step
 ```
-
+or 
+```
+yarn add @react-native-community/netinfo
+```
+If you are using React Native `0.60+` for iOS, run the following command as an additional step: 
+```
+cd ios && pod install && cd ..
+```
 ## Usage
 
 Please visit the [documentation with the Amplify Framework](https://aws-amplify.github.io/docs/js/api) for detailed instructions.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ npm install --save aws-appsync
 yarn add aws-appsync
 ```
 
+#### React Native Compatibility
+When using this library with React Native, you need to ensure you are using the correct version of the library based on your version of React Native. Take a look at the table below to determine what version to use.
+
+
+| `aws-appsync` version                     | Required React Native Version                                                 
+| ----------------------------------------- | -------------------------------------------------------------------------------- |
+| `2.x.x`                                   | `>= 0.60`
+| `1.x.x`                                   | `<= 0.59`                                                                      
+
+If you are using React Native `0.60` and above, you also need to install `@react-native-community/netinfo`:
+
+```
+npm install --save @react-native-community/netinfo
+cd ios && pod install && cd .. # iOS needs this extra step
+```
+
 ## Usage
 
 Please visit the [documentation with the Amplify Framework](https://aws-amplify.github.io/docs/js/api) for detailed instructions.


### PR DESCRIPTION
Adding instructions for using the library with React Native >= 0.60 after the 2.00 release

*Related Issues*
#443 
#434 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.