### PR TITLE
Add an optional 'customHeaders' field to AWSAppSyncClientOptions to easily add headers to requests

### DIFF
--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -131,6 +131,7 @@ export interface AWSAppSyncClientOptions {
     cacheOptions?: ApolloReducerConfig,
     disableOffline?: boolean,
     offlineConfig?: OfflineConfig,
+    customHeaders?,
 }
 
 export type OfflineConfig = Pick<Partial<StoreOptions<any>>, 'storage' | 'callback' | 'keyPrefix'> & {
@@ -178,6 +179,7 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
             callback = () => { },
             storeCacheRootMutation = false,
         } = {},
+        customHeaders = {},
     }: AWSAppSyncClientOptions, options?: Partial<ApolloClientOptions<TCacheShape>>) {
         const { cache: customCache = undefined, link: customLink = undefined } = options || {};
 
@@ -222,7 +224,7 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
                 };
             });
         });
-        const link = waitForRehydrationLink.concat(customLink || createAppSyncLink({ url, region, auth, complexObjectsCredentials, conflictResolver }));
+        const link = waitForRehydrationLink.concat(customLink || createAppSyncLink({ url, region, auth, complexObjectsCredentials, conflictResolver, resultsFetcherLink = createHttpLink({ uri: url, headers: customHeaders }) }));
 
         const newOptions = {
             ...options,


### PR DESCRIPTION
Description of changes:

This change allows passing a customHeaders argument to AWSAppSyncClientOptions to easily add headers to requests, by using the 'headers' field in createHttpLink.

For example, to add an authorization header, instead of doing this :

const AppSyncConfig = {
  url:  "url",
  region: "us-east-1",
  auth: {
    type: "API_KEY",
    apiKey: "key"
  }
};

const client = new AWSAppSyncClient(AppSyncConfig, {
  link: createAppSyncLink({
    ...AppSyncConfig,
    resultsFetcherLink: ApolloLink.from([
      setContext((request, previousContext) => ({
        headers: {
          ...previousContext.headers,
          "Authorization": "Bearer 1234"
        }
      })),
      createHttpLink({
        uri: AppSyncConfig.url
      })
    ])
  })
});

We could do this :

const AppSyncConfig = {
  url: "url",
  region: "us-east-1",
  auth: {
    type: "API_KEY",
    apiKey: "key",
 **customHeaders: {"Authorization" : "Bearer 1234"},**
  }
};

const client = new AWSAppSyncClient(AppSyncConfig);


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.