### PR TITLE
support passing custom 'fetch' function to 'createAppSyncLink' function

### DIFF
--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -83,10 +83,11 @@ class PermanentErrorLink extends ApolloLink {
 
 export const createAppSyncLink = ({
     url,
+    fetch,
     region,
     auth,
     complexObjectsCredentials,
-    resultsFetcherLink = createHttpLink({ uri: url }),
+    resultsFetcherLink = createHttpLink({ uri: url, fetch }),
     conflictResolver,
 }: {
     url: string,
@@ -95,6 +96,7 @@ export const createAppSyncLink = ({
     complexObjectsCredentials: CredentialsGetter,
     resultsFetcherLink?: ApolloLink,
     conflictResolver?: ConflictResolver,
+    fetch: GlobalFetch['fetch']
 }) => {
     const link = ApolloLink.from([
         createLinkWithStore((store) => new OfflineLink(store)),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Apollo supports passing custom fetch function in 'createHttpLink' function in order to avoid usage of global fetch function. 
I just added support for passing fetch property through function 'createAppSyncLink'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
