### PR TITLE
allow custom headers to be processed by a Subscription resolver's vtl

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -77,7 +77,8 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
     const {
       controlMessages: { [CONTROL_EVENTS_KEY]: controlEvents } = {
         [CONTROL_EVENTS_KEY]: undefined
-      }
+      },
+      headers
     } = operation.getContext();
     return new Observable<FetchResult>(observer => {
       const subscriptionId = uuid();
@@ -87,6 +88,7 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
         authenticationType: this.auth.type,
         query: print(query),
         region: this.region,
+        graphql_headers: () => ( headers ),
         variables,
         apiKey: this.auth.type === AUTH_TYPE.API_KEY ? this.auth.apiKey : "",
         credentials:


### PR DESCRIPTION
*Issue #, if available:*
fix for 496
*Description of changes:*

Include the context's header values when establishing a subscription.  This is so subscription data resolvers can access them (as they can with the legacy /mttq implementation)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
