### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ new Vue({
   el: '#app',
   router,
   components: { App },
-  provide: appsyncProvider.provide(),
+  apolloProvider:   appsyncProvider,
   template: '<App/>'
 })
 ```


### PR DESCRIPTION
The method .provide() in vue-apollo was deprecated.

*Description of changes:*

https://vue-apollo.netlify.com/guide/installation.html#_2-install-the-plugin-into-vue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
