### PR TITLE
Use >= 0.13.0 range in graphql dependency

### DIFF
--- a/packages/aws-appsync-auth-link/package.json
+++ b/packages/aws-appsync-auth-link/package.json
@@ -24,7 +24,6 @@
     "debug": "2.6.9"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.4",
     "@types/jest": "24",
     "@types/node": "^8.0.46",
     "@types/zen-observable": "^0.5.3",

--- a/packages/aws-appsync-react/package.json
+++ b/packages/aws-appsync-react/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@react-native-community/netinfo": "^4.1.3",
-    "@types/graphql": "0.12.4",
     "@types/react": "^16.0.25",
     "aws-appsync": "^3.0.2",
     "react": "^16.1.1",

--- a/packages/aws-appsync-subscription-link/package.json
+++ b/packages/aws-appsync-subscription-link/package.json
@@ -29,11 +29,10 @@
   },
   "devDependencies": {
     "@redux-offline/redux-offline": "2.5.2-native.0",
-    "@types/graphql": "0.12.4",
     "@types/jest": "24",
     "@types/node": "^8.0.46",
     "@types/zen-observable": "^0.5.3",
-    "graphql": "0.13.0",
+    "graphql": ">=0.13.0",
     "graphql-tag": "^2.9.2",
     "jest": "24",
     "node-fetch": "^2.2.0",

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -30,7 +30,7 @@
     "aws-appsync-subscription-link": "^2.0.1",
     "aws-sdk": "2.518.0",
     "debug": "2.6.9",
-    "graphql": "0.13.0",
+    "graphql": ">=0.13.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "setimmediate": "^1.0.5",
@@ -38,7 +38,6 @@
     "uuid": "3.x"
   },
   "devDependencies": {
-    "@types/graphql": "0.12.4",
     "@types/jest": "24",
     "@types/node": "^8.0.46",
     "@types/zen-observable": "^0.5.3",


### PR DESCRIPTION
Allows to use any version of graphql-js by defining a range `>= 0.13.0` in dependencies.

Related #545

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
