### PR TITLE
Upgrading redux-offline and netinfo dependencies for react native

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 ![npm](https://img.shields.io/npm/dm/aws-appsync.svg)
 
 
-package | version
---- | ---
-aws-appsync | ![npm](https://img.shields.io/npm/v/aws-appsync.svg)
-aws-appsync-react | ![npm](https://img.shields.io/npm/v/aws-appsync-react.svg)
+| package           | version                                                    |
+| ----------------- | ---------------------------------------------------------- |
+| aws-appsync       | ![npm](https://img.shields.io/npm/v/aws-appsync.svg)       |
+| aws-appsync-react | ![npm](https://img.shields.io/npm/v/aws-appsync-react.svg) |
 
 
 ## Installation    
@@ -34,23 +34,23 @@ For version <= 2.x.x, the selection set for the subscription will be the mutatio
 When using this library with React Native, you need to ensure you are using the correct version of the library based on your version of React Native. Take a look at the table below to determine what version to use.
 
 
-| `aws-appsync` version                     | Required React Native Version                                                 
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| `2.x.x`                                   | `>= 0.60`
-| `1.x.x`                                   | `<= 0.59`                                                                      
+| `aws-appsync` version | Required React Native Version |
+| --------------------- | ----------------------------- |
+| `2.x.x`               | `>= 0.60`                     |
+| `1.x.x`               | `<= 0.59`                     |
 
-If you are using React Native `0.60` and above, you also need to install `@react-native-community/netinfo`:
+If you are using React Native `0.60` and above, you also need to install `@react-native-community/netinfo` and `@react-native-community/async-storage`:
 
 ```
-npm install --save @react-native-community/netinfo@4.7.0
+npm install --save @react-native-community/netinfo@5.9.4 @react-native-community/async-storage
 ```
 or 
 ```
-yarn add @react-native-community/netinfo@4.7.0
+yarn add @react-native-community/netinfo@5.9.4 @react-native-community/async-storage
 ```
 If you are using React Native `0.60+` for iOS, run the following command as an additional step: 
 ```
-cd ios && pod install && cd ..
+npx pod-install
 ```
 ## Usage
 

--- a/packages/aws-appsync-react/package.json
+++ b/packages/aws-appsync-react/package.json
@@ -20,13 +20,13 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@react-native-community/netinfo": "4.x.x",
+    "@react-native-community/netinfo": "^5.0.0",
     "aws-appsync": "3.x.x",
     "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0",
     "react-apollo": "2.x"
   },
   "devDependencies": {
-    "@react-native-community/netinfo": "^4.1.3",
+    "@react-native-community/netinfo": "^5.0.0",
     "@types/react": "^16.0.25",
     "aws-appsync": "^3.0.2",
     "react": "^16.1.1",

--- a/packages/aws-appsync-react/package.json
+++ b/packages/aws-appsync-react/package.json
@@ -20,7 +20,6 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@react-native-community/netinfo": "^5.0.0",
     "aws-appsync": "3.x.x",
     "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0",
     "react-apollo": "2.x"

--- a/packages/aws-appsync-react/src/rehydrated-rn.tsx
+++ b/packages/aws-appsync-react/src/rehydrated-rn.tsx
@@ -58,7 +58,7 @@ export default class Rehydrated extends React.Component<RehydratedProps, Rehydra
 
     async componentDidMount() {
         await this.context.client.hydrated();
-        await NetInfo.isConnected.fetch();
+        await NetInfo.fetch();
 
         this.setState({
             rehydrated: true

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -37,5 +37,9 @@
     "url": "^0.11.0",
     "uuid": "3.x"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "peerDependencies": {
+    "@react-native-community/async-storage": "^1.11.0",
+    "@react-native-community/netinfo": "^5.0.0"
+  }
 }

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -19,7 +19,7 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "@redux-offline/redux-offline": "2.5.2-native.0",
+    "@redux-offline/redux-offline": "2.5.2-native.3",
     "apollo-cache-inmemory": "1.3.12",
     "apollo-client": "2.4.6",
     "apollo-link": "1.2.3",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrading redux-offline and netinfo dependencies for react native to use latest versions. This is because newer versions of NetInfo deprecated some APIs that were used by the version of redux-offline we were using.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
