### PR TITLE
Updated link packages to use Apollo 3

### DIFF
--- a/packages/aws-appsync-auth-link/package.json
+++ b/packages/aws-appsync-auth-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-appsync-auth-link",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "description": "AWS Mobile AppSync Auth Link for JavaScript",
@@ -19,7 +19,7 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "apollo-link": "^1.2.3",
+    "@apollo/client": "^3.0.0-beta.44",
     "aws-sdk": "^2.518.0",
     "debug": "2.6.9"
   }

--- a/packages/aws-appsync-auth-link/src/auth-link.ts
+++ b/packages/aws-appsync-auth-link/src/auth-link.ts
@@ -2,9 +2,7 @@
  * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Observable, Operation, NextLink } from 'apollo-link';
-import { ApolloLink } from 'apollo-link';
-import { ExecutionResult } from 'graphql';
+import { ApolloLink, Observable } from '@apollo/client';
 import { print } from 'graphql/language/printer';
 
 import { Signer } from './signer';

--- a/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
+++ b/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
@@ -1,5 +1,5 @@
 import { AUTH_TYPE } from "aws-appsync-auth-link";
-import { execute } from "apollo-link";
+import { execute } from "@apollo/client";
 import gql from 'graphql-tag';
 import { AppSyncRealTimeSubscriptionHandshakeLink } from '../../src/realtime-subscription-handshake-link';
 
@@ -75,7 +75,7 @@ describe("RealTime subscription link", () => {
             region: 'us-east-1',
             url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
         });
-        
+
         execute(link, { query }).subscribe({
             error: (err) => {
                 console.log({ err });
@@ -112,7 +112,7 @@ describe("RealTime subscription link", () => {
             region: 'us-east-1',
             url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
         });
-        
+
         execute(link, { query }).subscribe({
             error: (err) => {
                 console.log({ err });
@@ -149,7 +149,7 @@ describe("RealTime subscription link", () => {
             region: 'us-east-1',
             url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
         });
-        
+
         execute(link, { query }).subscribe({
             error: (err) => {
                 console.log({ err });

--- a/packages/aws-appsync-subscription-link/package.json
+++ b/packages/aws-appsync-subscription-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-appsync-subscription-link",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "description": "AWS Mobile AppSync SDK for JavaScript",
@@ -19,10 +19,9 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "apollo-link": "^1.2.3",
-    "apollo-link-context": "^1.0.9",
-    "apollo-link-http": "^1.3.1",
-    "apollo-link-retry": "^2.2.5",
+    "@apollo/client": "^3.0.0-beta.44",
+    "@apollo/link-context": "^2.0.0-beta.3",
+    "@apollo/link-retry": "^2.0.0-beta.3",
     "aws-appsync-auth-link": "^2.0.2",
     "debug": "2.6.9",
     "url": "^0.11.0"
@@ -31,6 +30,6 @@
     "@redux-offline/redux-offline": "2.5.2-native.0"
   },
   "peerDependencies": {
-    "apollo-client": "2.x"
+    "@apollo/client": "3.x"
   }
 }

--- a/packages/aws-appsync-subscription-link/package.json
+++ b/packages/aws-appsync-subscription-link/package.json
@@ -20,8 +20,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.0",
-    "@apollo/link-context": "^2.0.0-beta.3",
-    "@apollo/link-retry": "^2.0.0-beta.3",
     "aws-appsync-auth-link": "^2.0.3",
     "debug": "2.6.9",
     "url": "^0.11.0"

--- a/packages/aws-appsync-subscription-link/src/index.ts
+++ b/packages/aws-appsync-subscription-link/src/index.ts
@@ -2,8 +2,7 @@ import {
   SubscriptionHandshakeLink,
   CONTROL_EVENTS_KEY
 } from "./subscription-handshake-link";
-import { ApolloLink, Observable } from "apollo-link";
-import { createHttpLink } from "apollo-link-http";
+import { ApolloLink, Observable, createHttpLink } from "@apollo/client";
 import { getMainDefinition } from "apollo-utilities";
 import { NonTerminatingLink } from "./non-terminating-link";
 import { OperationDefinitionNode } from "graphql";

--- a/packages/aws-appsync-subscription-link/src/non-terminating-http-link.ts
+++ b/packages/aws-appsync-subscription-link/src/non-terminating-http-link.ts
@@ -2,11 +2,11 @@
  * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { createHttpLink, FetchOptions } from 'apollo-link-http';
+import { createHttpLink, HttpOptions } from '@apollo/client';
 import { NonTerminatingLink } from './non-terminating-link';
 
 export class NonTerminatingHttpLink extends NonTerminatingLink {
-    constructor(contextKey: string, options: FetchOptions) {
+    constructor(contextKey: string, options: HttpOptions) {
         const link = createHttpLink(options);
 
         super(contextKey, { link });

--- a/packages/aws-appsync-subscription-link/src/non-terminating-link.ts
+++ b/packages/aws-appsync-subscription-link/src/non-terminating-link.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { ApolloLink, NextLink } from '@apollo/client';
-import { setContext } from '@apollo/link-context';
+import { setContext } from '@apollo/client/link/context';
 
 export class NonTerminatingLink extends ApolloLink {
 

--- a/packages/aws-appsync-subscription-link/src/non-terminating-link.ts
+++ b/packages/aws-appsync-subscription-link/src/non-terminating-link.ts
@@ -2,8 +2,8 @@
  * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, NextLink } from 'apollo-link';
-import { setContext } from 'apollo-link-context';
+import { ApolloLink, NextLink } from '@apollo/client';
+import { setContext } from '@apollo/link-context';
 
 export class NonTerminatingLink extends ApolloLink {
 

--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, Observable, Operation, FetchResult } from "apollo-link";
+import { ApolloLink, Observable, Operation, FetchResult } from "@apollo/client";
 
 import { rootLogger } from "./utils";
 

--- a/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
@@ -2,11 +2,10 @@
  * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, Observable, Operation, FetchResult } from "apollo-link";
+import { ApolloLink, Observable, Operation, FetchResult, ApolloError } from "@apollo/client";
 
 import { rootLogger } from "./utils";
 import * as Paho from './vendor/paho-mqtt';
-import { ApolloError } from "apollo-client";
 import { FieldNode } from "graphql";
 import { getMainDefinition } from "apollo-utilities";
 


### PR DESCRIPTION
*Issue #:* #525 

*Description of changes:* Updated imports to use the new scoped `@apollo/client` imports. Also bumped version number of both packages to 3.0.0 due to this most likely being a breaking change for consumers (although all tests pass on my machine!)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
