### PR TITLE
fix(aws-appsync-subscription-link): change relativ

### DIFF
--- a/packages/aws-appsync-subscription-link/src/utils/retry.ts
+++ b/packages/aws-appsync-subscription-link/src/utils/retry.ts
@@ -1,4 +1,4 @@
-import { rootLogger } from ".";
+import { rootLogger } from "./index";
 import { DelayFunction } from "../types";
 
 const logger = rootLogger.extend("retry");


### PR DESCRIPTION
e import '.' to explicitly defining 'index' in retry.ts

*Issue #, if available:*

I've just setup an Expo/React-Native application and I wanted to use `aws-appsync-subscription-link` and I run into a bug which is related to an import statement. It did only materialize on real iOS/Android devices (haven't tried it on simulators) but it did NOT materialize on RN's web render. To help you reproduce, I quickly paste my `package.json`-s relevant part. I do not know the exact reason though but I managed to make everything work.
```
  "dependencies": {
    "@apollo/react-hooks": "^3.1.5",
    "@eva-design/eva": "^2.0.0",
    "@expo/webpack-config": "^0.12.9",
    "@react-native-community/masked-view": "^0.1.6",
    "@react-native-community/netinfo": "^4.7.0",
    "@react-navigation/bottom-tabs": "^5.4.5",
    "@react-navigation/native": "^5.4.0",
    "@ui-kitten/components": "^5.0.0",
    "apollo-cache-inmemory": "^1.6.6",
    "apollo-client": "^2.6.10",
    "apollo-link": "^1.2.14",
    "aws-appsync-auth-link": "^2.0.2",
    "aws-appsync-subscription-link": "^2.1.0",
    "cross-fetch": "^3.0.4",
    "expo": "~37.0.3",
    "graphql": "^15.0.0",
    "graphql-tag": "^2.10.3",
    "lodash": "^4.17.15",
    "react": "~16.9.0",
    "react-apollo": "^3.1.5",
    "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
    "react-native-eva-icons": "^1.3.1",
    "react-native-gesture-handler": "~1.6.0",
    "react-native-safe-area-context": "0.7.3",
    "react-native-screens": "~2.2.0",
    "react-native-svg": "11.0.1",
    "react-native-web": "~0.11.7"
  },
  "devDependencies": {
    "@babel/core": "^7.8.6",
    "@react-native-community/eslint-config": "^1.1.0",
    "@types/enzyme": "^3.10.5",
    "@types/jest": "^25.2.2",
    "@types/react": "~16.9.23",
    "@types/react-native": "~0.61.17",
    "@types/react-test-renderer": "^16.9.2",
    "@typescript-eslint/eslint-plugin": "^2.33.0",
    "babel-jest": "^26.0.1",
    "babel-plugin-module-resolver": "^4.0.0",
    "babel-preset-expo": "~8.1.0",
    "enzyme": "^3.11.0",
    "enzyme-adapter-react-16": "^1.15.2",
    "eslint": "^7.0.0",
    "eslint-config-airbnb-typescript": "^7.2.1",
    "eslint-plugin-import": "^2.20.2",
    "eslint-plugin-jsx-a11y": "^6.2.3",
    "eslint-plugin-react": "^7.20.0",
    "eslint-plugin-react-hooks": "^4.0.2",
    "eslint-plugin-unused-imports": "^0.1.3",
    "husky": "^4.2.5",
    "import-sort-style-module": "^6.0.0",
    "jest": "^26.0.1",
    "jest-environment-enzyme": "^7.1.2",
    "jest-enzyme": "^7.1.2",
    "lint-staged": "^10.2.2",
    "prettier": "^2.0.5",
    "prettier-plugin-import-sort": "0.0.4",
    "react-dom": "^16.9.0",
    "ts-jest": "^26.0.0",
    "typescript": "~3.8.3"
  },
```


The issue was the following:
```
TypeError: undefined is not an object (evaluating '_1.rootLogger.extend'
``` 
which was originating from `aws-appsync-subscription-link/src/utils/retry.ts` from an import 
statement:
```ts
import { rootLogger } from ".";
```

Changing it to the following makes everything work on both iOS and Android, and all tests pass.
```ts
import { rootLogger } from "./index";
```
*Description of changes:*
Changing the incorrect import statement to prevent import bugs on all platforms.

Let me know if I can provide anything further that can help you reproduce the bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
