### PR TITLE
fix(subscription) Updated request return type correctly match apollo-link

### DIFF
--- a/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
@@ -51,7 +51,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
         this.subsInfoContextKey = subsInfoContextKey;
     }
 
-    request(operation: Operation) {
+    request(operation: Operation): Observable<FetchResult> | null {
         const {
             [this.subsInfoContextKey]: subsInfo,
             controlMessages: { [CONTROL_EVENTS_KEY]: controlEvents } = { [CONTROL_EVENTS_KEY]: undefined }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Small change to specify the return type on a method implemented from `ApolloLink`.

Current type which doesn't compile with apollo-link `1.2.14`.

```
    request(operation: Operation): Observable<unknown>;
```

New type after change which compiles

```
    request(operation: Operation): Observable<FetchResult> | null;
```

Compile error before change was as follows:

```
ERROR in releases-ui/node_modules/aws-appsync-subscription-link/lib/subscription-handshake-link.d.ts(18,5):
18:5 Property 'request' in type 'SubscriptionHandshakeLink' is not assignable to the same property in base type 'ApolloLink'.
  Type '(operation: Operation) => Observable<unknown>' is not assignable to type '(operation: Operation, forward?: NextLink | undefined) => Observable<FetchResult<{ [key: string]: any; }, Record<string, any>, Record<string, any>>> | null'.
    Type 'Observable<unknown>' is not assignable to type 'Observable<FetchResult<{ [key: string]: any; }, Record<string, any>, Record<string, any>>>'.
      Type 'unknown' is not assignable to type 'FetchResult<{ [key: string]: any; }, Record<string, any>, Record<string, any>>'.
        Type 'unknown' is not assignable to type 'ExecutionResult<{ [key: string]: any; }>'.
    16 |     private clientObservers;
    17 |     constructor(subsInfoContextKey: any);
  > 18 |     request(operation: Operation): Observable<unknown>;
       |     ^
    19 |     connectNewClients(connectionInfo: MqttConnectionInfo[], observer: ZenObservable.Observer<FetchResult>, operation: Operation): Promise<any[]>;
    20 |     connectNewClient(connectionInfo: MqttConnectionInfo, observer: ZenObservable.Observer<FetchResult>, selectionNames: string[]): Promise<any>;
    21 |     subscribeToTopics<T>(client: any, topics: string[], observer: ZenObservable.Observer<T>): Promise<unknown[]>;
Version: typescript 3.9.3
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

✅ 👍 💯 