### PR TITLE
Remove `global.localStorage` call in paho-mqtt file for incognito mode

### DIFF
--- a/packages/aws-appsync-subscription-link/src/vendor/paho-mqtt.js
+++ b/packages/aws-appsync-subscription-link/src/vendor/paho-mqtt.js
@@ -106,7 +106,7 @@ function onMessageArrived(message) {
 	/**
 	 * @private
 	 */
-	var localStorage = global.localStorage || (function () {
+	var localStorage = (function () {
 		var data = {};
 
 		return {


### PR DESCRIPTION
**What was the problem ?**

`paho-mqtt.js` was using the code `global.localStorage`. 

In Private navigation (aka incognito mode), cookies are by default blocked for third party. The fallback was to use localStorage but this file is attaching localStorage to global and access to the global window is forbidden which resulted in an error.

`DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document`

**Why this modification:**

Remove this little piece of code will allow `aws-appsync` to be correctly used even in private navigation. 

