### PR TITLE
Fix: Avoid error from null value for observer in timeoutStartSubscriptionAck function

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -713,6 +713,11 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
     const { observer, query, variables } = this.subscriptionObserverMap.get(
       subscriptionId
     );
+
+    if (!observer) {
+      return;
+    }
+
     this.subscriptionObserverMap.set(subscriptionId, {
       observer,
       query,


### PR DESCRIPTION
*Issue #, if available:*
#515 #544 #596 

*Description of changes:*
An if statement to make sure that the `observer` exists before it tries to call the properties of `observer` in timeoutStartSubscriptionAck function


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
