### PR TITLE
Replace @apollo/client/core from @apollo/client to avoid the React dependency

### DIFF
--- a/packages/aws-appsync-auth-link/src/auth-link.ts
+++ b/packages/aws-appsync-auth-link/src/auth-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, Observable } from '@apollo/client';
+import { ApolloLink, Observable } from '@apollo/client/core';
 import { print } from 'graphql/language/printer';
 
 import { Signer } from './signer';

--- a/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
+++ b/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
@@ -1,5 +1,5 @@
 import { AUTH_TYPE } from "aws-appsync-auth-link";
-import { execute } from "@apollo/client";
+import { execute } from "@apollo/client/core";
 import gql from 'graphql-tag';
 import { AppSyncRealTimeSubscriptionHandshakeLink } from '../../src/realtime-subscription-handshake-link';
 

--- a/packages/aws-appsync-subscription-link/src/index.ts
+++ b/packages/aws-appsync-subscription-link/src/index.ts
@@ -2,7 +2,7 @@ import {
   SubscriptionHandshakeLink,
   CONTROL_EVENTS_KEY
 } from "./subscription-handshake-link";
-import { ApolloLink, Observable, createHttpLink } from "@apollo/client";
+import { ApolloLink, Observable, createHttpLink } from "@apollo/client/core";
 import { getMainDefinition } from "apollo-utilities";
 import { NonTerminatingLink } from "./non-terminating-link";
 import { OperationDefinitionNode } from "graphql";

--- a/packages/aws-appsync-subscription-link/src/non-terminating-http-link.ts
+++ b/packages/aws-appsync-subscription-link/src/non-terminating-http-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { createHttpLink, HttpOptions } from '@apollo/client';
+import { createHttpLink, HttpOptions } from '@apollo/client/core';
 import { NonTerminatingLink } from './non-terminating-link';
 
 export class NonTerminatingHttpLink extends NonTerminatingLink {

--- a/packages/aws-appsync-subscription-link/src/non-terminating-link.ts
+++ b/packages/aws-appsync-subscription-link/src/non-terminating-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, NextLink } from '@apollo/client';
+import { ApolloLink, NextLink } from '@apollo/client/core';
 import { setContext } from '@apollo/client/link/context';
 
 export class NonTerminatingLink extends ApolloLink {

--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, Observable, Operation, FetchResult } from "@apollo/client";
+import { ApolloLink, Observable, Operation, FetchResult } from "@apollo/client/core";
 
 import { rootLogger } from "./utils";
 

--- a/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, Observable, Operation, FetchResult, ApolloError } from "@apollo/client";
+import { ApolloLink, Observable, Operation, FetchResult, ApolloError } from "@apollo/client/core";
 
 import { rootLogger } from "./utils";
 import * as Paho from './vendor/paho-mqtt';


### PR DESCRIPTION
*Issue #, if available:*

fix for #598 

*Description of changes:*

Replace to import statements of @apollo/client/core from import statements of @apollo/client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
