### PR TITLE
Fix: Avoid error from null value for observer in timeoutDisconnect function

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -696,6 +696,10 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
 
   private _timeoutDisconnect() {
     this.subscriptionObserverMap.forEach(({ observer }) => {
+      if (!observer) {
+        return;
+      }
+
       observer.error({
         errors: [{ ...new GraphQLError(`Timeout disconnect`) }]
       });


### PR DESCRIPTION
*Issue #, if available:*
#515 #544 #596 

*Description of changes:*
An if statement to make sure that the `observer` exists before it tries to call the properties of `observer` in timeoutDisconnect function.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
