### PR TITLE
fix: using apollo core to avoid loading react

### DIFF
--- a/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
+++ b/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
@@ -1,5 +1,5 @@
 import { AUTH_TYPE } from "aws-appsync-auth-link";
-import { execute } from "@apollo/client";
+import { execute } from "@apollo/client/core";
 import gql from 'graphql-tag';
 import { AppSyncRealTimeSubscriptionHandshakeLink } from '../../src/realtime-subscription-handshake-link';
 

--- a/packages/aws-appsync-subscription-link/src/index.ts
+++ b/packages/aws-appsync-subscription-link/src/index.ts
@@ -2,7 +2,7 @@ import {
   SubscriptionHandshakeLink,
   CONTROL_EVENTS_KEY
 } from "./subscription-handshake-link";
-import { ApolloLink, Observable, createHttpLink } from "@apollo/client";
+import { ApolloLink, Observable, createHttpLink } from "@apollo/client/core";
 import { getMainDefinition } from "apollo-utilities";
 import { NonTerminatingLink } from "./non-terminating-link";
 import { OperationDefinitionNode } from "graphql";

--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, Observable, Operation, FetchResult } from "@apollo/client";
+import { ApolloLink, Observable, Operation, FetchResult } from "@apollo/client/core";
 
 import { rootLogger } from "./utils";
 

--- a/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
@@ -2,7 +2,7 @@
  * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ApolloLink, Observable, Operation, FetchResult, ApolloError } from "@apollo/client";
+import { ApolloLink, Observable, Operation, FetchResult, ApolloError } from "@apollo/client/core";
 
 import { rootLogger } from "./utils";
 import * as Paho from './vendor/paho-mqtt';


### PR DESCRIPTION
*Issue:*
https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/611

*Description of changes:*
As described in the issue, the apollo client loads react by default which is not optimal. Instead of using `@apollo/client` I import `@apollo/client/core` which is just the apollo functions needed!

The apollo team described the migration process on this page: https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/ . They use the package `@apollo/client` because they are in a react project. As described here https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/#using-apollo-client-without-react, "Apollo Client 3.0 includes built-in support for React hooks, but it absolutely still supports non-React view layers. To use Apollo Client 3.0 with Vue, Angular, or another view layer of your choosing, import ApolloClient from the @apollo/client/core entry point". Importing `@apollo/client/core` works with all js frameworks and doesn't force react to be loaded.

Happy to modify if you have feedback
