### PR TITLE
fix: Bump aws-sdk to address CVE-2020-28472

### DIFF
--- a/packages/aws-appsync-auth-link/package.json
+++ b/packages/aws-appsync-auth-link/package.json
@@ -19,7 +19,7 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "aws-sdk": "^2.518.0",
+    "aws-sdk": "^2.814.0",
     "debug": "2.6.9"
   },
   "devDependencies": {

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -28,7 +28,7 @@
     "apollo-link-retry": "2.2.7",
     "aws-appsync-auth-link": "^2.0.3",
     "aws-appsync-subscription-link": "^2.2.1",
-    "aws-sdk": "2.518.0",
+    "aws-sdk": "^2.814.0",
     "debug": "2.6.9",
     "graphql": "0.13.0",
     "redux": "^3.7.2",


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JS-AWSSDK-1059424
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28472

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
