### PR TITLE
Fix IAM authed realtime-subscription-handshake-link returning a BadRequestException

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -79,7 +79,6 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
       controlMessages: { [CONTROL_EVENTS_KEY]: controlEvents } = {
         [CONTROL_EVENTS_KEY]: undefined
       },
-      headers
     } = operation.getContext();
     return new Observable<FetchResult>(observer => {
       if (!this.url) {
@@ -101,7 +100,6 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
           authenticationType: this.auth.type,
           query: print(query),
           region: this.region,
-          graphql_headers: () => (headers),
           variables,
           apiKey: this.auth.type === AUTH_TYPE.API_KEY ? this.auth.apiKey : "",
           credentials:
@@ -290,8 +288,7 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
         authenticationType,
         region,
         credentials,
-        jwtToken,
-        graphql_headers
+        jwtToken
       });
     } catch (err) {
       const { message = "" } = err;
@@ -347,8 +344,7 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
     apiKey,
     region,
     credentials,
-    jwtToken,
-    graphql_headers
+    jwtToken
   }): Promise<void> {
     if (this.socketStatus === SOCKET_STATUS.READY) {
       return;
@@ -365,8 +361,8 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
           );
 
           const payloadString = "{}";
-          const headerString = JSON.stringify({
-            ...(await this._awsRealTimeHeaderBasedAuth({
+          const headerString = JSON.stringify(
+            await this._awsRealTimeHeaderBasedAuth({
               authenticationType,
               payload: payloadString,
               canonicalUri: "/connect",
@@ -375,9 +371,8 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
               region,
               credentials,
               jwtToken
-            })),
-            ...(await graphql_headers()),
-          });
+            })
+          );
           const headerQs = Buffer.from(headerString).toString("base64");
 
           const payloadQs = Buffer.from(payloadString).toString("base64");

--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -290,7 +290,8 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
         authenticationType,
         region,
         credentials,
-        jwtToken
+        jwtToken,
+        graphql_headers
       });
     } catch (err) {
       const { message = "" } = err;
@@ -346,7 +347,8 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
     apiKey,
     region,
     credentials,
-    jwtToken
+    jwtToken,
+    graphql_headers
   }): Promise<void> {
     if (this.socketStatus === SOCKET_STATUS.READY) {
       return;
@@ -363,8 +365,8 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
           );
 
           const payloadString = "{}";
-          const headerString = JSON.stringify(
-            await this._awsRealTimeHeaderBasedAuth({
+          const headerString = JSON.stringify({
+            ...(await this._awsRealTimeHeaderBasedAuth({
               authenticationType,
               payload: payloadString,
               canonicalUri: "/connect",
@@ -373,8 +375,9 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
               region,
               credentials,
               jwtToken
-            })
-          );
+            })),
+            ...(await graphql_headers()),
+          });
           const headerQs = Buffer.from(headerString).toString("base64");
 
           const payloadQs = Buffer.from(payloadString).toString("base64");


### PR DESCRIPTION
***Issue #, if available:***
https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/619

***Description of changes:***
I believe that this issue stems from the fact that `graphql_headers` seem to be an option passed in and used here to create the "start subscription" message:
https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts#L256
We are creating the options here:
https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts#L104

but these `graphql_headers` are not used to initialize the websocket connection:
https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/master/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts#L366

I've opted to fix this issue by passing the `graphql_headers` to `_initializeWebSocketConnection` so that the headers match.

This change seems to have been introduced here:
https://github.com/awslabs/aws-mobile-appsync-sdk-js/blame/master/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts#L104
In a PR which made progress towards making the subscription link work like the amplify one. However I noted that the amplify use of `_startSubscriptionWithAWSAppSyncRealTime` does not pass in `graphql_headers` so maybe the actual fix is for us to not set the `graphql_headers` option?
https://github.com/aws-amplify/amplify-js/blob/5a8ea9c5b736e49d0cbfa06e0f0e9405a942c48d/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts#L185

If the preferred fix is to actually remove the `graphql_headers` options being passed to `_startSubscriptionWithAWSAppSyncRealTime` then I can make that change.


**By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.**
