### PR TITLE
fix: check observer exists handleIncomingSubscriptionMessage

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -648,6 +648,10 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
 
     logger({ id, observer, query, variables });
 
+    if (!observer) {
+      return;
+    }
+
     if (type === MESSAGE_TYPES.GQL_DATA && payload && payload.data) {
       if (observer) {
         observer.next(payload);


### PR DESCRIPTION
No Issue, although similar in nature to #515 #544 #596 (and PRs #609, $595). 

Check observer exists before calling its methods in AppSyncRealTimeSubscriptionHandshakeLink##_handleIncomingSubscriptionMessage

This observer is being defaulted to null here, so I assume checking that and ignoring the event after logging is fine since I would expect the method to bail there rather than initialize to an invalid value?
https://github.com/aw/aws-mobile-appsync-sdk-js/blob/1b71926bad4f31718d5d8dcd5971448faaa12697/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts#L641

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 
I Agree.
