### PR TITLE
fix: aws-appsync dependencies

### DIFF
--- a/packages/aws-appsync-react/package.json
+++ b/packages/aws-appsync-react/package.json
@@ -21,7 +21,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "aws-appsync": "3.x.x",
+    "aws-appsync": "3.x.x || 4.x.x",
     "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0",
     "react-apollo": "2.x"
   },

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -26,8 +26,8 @@
     "apollo-link-context": "1.0.11",
     "apollo-link-http": "1.5.8",
     "apollo-link-retry": "2.2.7",
-    "aws-appsync-auth-link": "^2.0.3",
-    "aws-appsync-subscription-link": "^2.2.1",
+    "aws-appsync-auth-link": "^3.0.4",
+    "aws-appsync-subscription-link": "^3.0.6",
     "aws-sdk": "^2.814.0",
     "debug": "2.6.9",
     "graphql": "0.13.0",
@@ -36,6 +36,9 @@
     "setimmediate": "^1.0.5",
     "url": "^0.11.0",
     "uuid": "3.x"
+  },
+  "devDependencies": {
+    "@apollo/client": "^3.2.0"
   },
   "peerDependencies": {
     "@react-native-community/async-storage": "^1.11.0",

--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -8,6 +8,7 @@ import { InMemoryCache, ApolloReducerConfig, NormalizedCacheObject } from 'apoll
 import { ApolloLink, Observable, FetchResult, NextLink } from 'apollo-link';
 import { createHttpLink } from 'apollo-link-http';
 import { getMainDefinition } from 'apollo-utilities';
+import { ApolloLink as ApolloLinkV3 } from "@apollo/client";
 import { Store } from 'redux';
 
 import { OfflineCache, defaultDataIdFromObject } from './cache/index';
@@ -101,8 +102,11 @@ export const createAppSyncLink = ({
         new ConflictResolutionLink(conflictResolver),
         new ComplexObjectLink(complexObjectsCredentials),
         createRetryLink(ApolloLink.from([
-            new CatchErrorLink(() =>new AuthLink({ url, region, auth })),
-            new PermanentErrorLink(createSubscriptionHandshakeLink({ url, region, auth }, resultsFetcherLink))
+            new CatchErrorLink(() =>new AuthLink({ url, region, auth }) as unknown as ApolloLink),
+            new PermanentErrorLink(createSubscriptionHandshakeLink(
+                { url, region, auth }, 
+                resultsFetcherLink  as unknown as ApolloLinkV3)  as unknown as ApolloLink,
+            )
         ]))
     ].filter(Boolean));
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fix dependencies in `aws-appsync` to point to the correct versions.
I had to do some ugly castings as we need the sdk to work with both apollo 2.x and 3.x

Tested with a brand new CRA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
