### PR TITLE
feat(aws-appsync): Remove storeCacheRootMutation flag

### DIFF
--- a/packages/aws-appsync/src/cache/offline-cache.ts
+++ b/packages/aws-appsync/src/cache/offline-cache.ts
@@ -46,7 +46,6 @@ export interface OfflineCache extends AppState {
 
 export type OfflineCacheOptions = {
     store: Store<OfflineCache>,
-    storeCacheRootMutation?: boolean,
 }
 
 function isOfflineCacheOptions(obj: any): obj is OfflineCacheOptions {

--- a/packages/aws-appsync/src/cache/offline-cache.ts
+++ b/packages/aws-appsync/src/cache/offline-cache.ts
@@ -56,16 +56,14 @@ function isOfflineCacheOptions(obj: any): obj is OfflineCacheOptions {
 export default class MyCache extends InMemoryCache {
 
     private store: Store<OfflineCache>;
-    private storeCacheRootMutation: boolean = false;
 
     constructor(optionsOrStore: Store<OfflineCache> | OfflineCacheOptions, config: ApolloReducerConfig = {}) {
         super(config);
 
         if (isOfflineCacheOptions(optionsOrStore)) {
-            const { store, storeCacheRootMutation = false } = optionsOrStore;
+            const { store } = optionsOrStore;
 
             this.store = store;
-            this.storeCacheRootMutation = storeCacheRootMutation;
         } else {
             this.store = optionsOrStore;
         }
@@ -92,7 +90,7 @@ export default class MyCache extends InMemoryCache {
     write(write: Cache.WriteOptions) {
         super.write(write);
 
-        if (!this.storeCacheRootMutation && write.dataId === 'ROOT_MUTATION') {
+        if (write.dataId === 'ROOT_MUTATION') {
             this.data.delete('ROOT_MUTATION');
         }
 

--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -148,9 +148,7 @@ export interface AWSAppSyncClientOptions {
     offlineConfig?: OfflineConfig,
 }
 
-export type OfflineConfig = Pick<Partial<StoreOptions<any>>, 'storage' | 'callback' | 'keyPrefix'> & {
-    storeCacheRootMutation?: boolean
-};
+export type OfflineConfig = Pick<Partial<StoreOptions<any>>, 'storage' | 'callback' | 'keyPrefix'>;
 
 // TODO: type defs
 export type OfflineCallback = (err: any, success: any) => void;
@@ -191,7 +189,6 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
             storage = undefined,
             keyPrefix = undefined,
             callback = () => { },
-            storeCacheRootMutation = false,
         } = {},
     }: AWSAppSyncClientOptions, options?: Partial<ApolloClientOptions<TCacheShape>>) {
         const { cache: customCache = undefined, link: customLink = undefined } = options || {};
@@ -220,7 +217,7 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
         });
         const cache: ApolloCache<any> = disableOffline
             ? (customCache || new InMemoryCache(cacheOptions))
-            : new OfflineCache({ store, storeCacheRootMutation }, cacheOptions);
+            : new OfflineCache({ store }, cacheOptions);
 
         const waitForRehydrationLink = new ApolloLink((op, forward) => {
             let handle = null;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removes `storeCacheRootMutation` for security reasons outlined [here](https://github.com/apollographql/apollo-client/issues/3592). The library is secure as this flag defaults to false and call `this.data.delete('ROOT_MUTATION')` here https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/fc173bfe3ce262b1dba422021fc57097c4926b7b/packages/aws-appsync/src/cache/offline-cache.ts#L95-L97 

While this flag defaults to false, we're removing this flag in case user changes this flag and spawn vulnerabilities.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
