### PR TITLE
Feat: lambda authorizer apollov2

### DIFF
--- a/packages/aws-appsync-auth-link/__tests__/link/auth-link-test.ts
+++ b/packages/aws-appsync-auth-link/__tests__/link/auth-link-test.ts
@@ -1,0 +1,110 @@
+import { authLink, AUTH_TYPE } from "../../src/auth-link";
+import { execute, ApolloLink, Observable } from "apollo-link";
+import gql from 'graphql-tag';
+
+describe("Auth link", () => { 
+    test('Test AWS_LAMBDA authorizer for queries', (done) => {
+        const query = gql`query { someQuery { aField } }`
+
+        const link = authLink({
+            auth: {
+                type: AUTH_TYPE.AWS_LAMBDA,
+                token: 'token'
+            }, 
+            region: 'us-east-1',
+            url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
+        })
+
+        
+        const spyLink = new ApolloLink((operation, forward) => {
+            const { headers: { Authorization} } = operation.getContext();
+            expect(Authorization).toBe('token');
+            done();
+
+            return new Observable(() => {});
+        })
+        
+        const testLink = ApolloLink.from([link, spyLink]);
+
+        execute(testLink, { query }).subscribe({ })
+    });
+
+    test('Test AMAZON_COGNITO_USER_POOLS authorizer for queries', (done) => {
+        const query = gql`query { someQuery { aField } }`
+
+        const link = authLink({
+            auth: {
+                type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+                jwtToken: 'token'
+            }, 
+            region: 'us-east-1',
+            url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
+        })
+
+        
+        const spyLink = new ApolloLink((operation, forward) => {
+            const { headers: { Authorization} } = operation.getContext();
+            expect(Authorization).toBe('token');
+            done();
+
+            return new Observable(() => {});
+        })
+        
+        const testLink = ApolloLink.from([link, spyLink]);
+
+        execute(testLink, { query }).subscribe({ })
+    });
+
+    test('Test OPENID_CONNECT authorizer for queries', (done) => {
+        const query = gql`query { someQuery { aField } }`
+
+        const link = authLink({
+            auth: {
+                type: AUTH_TYPE.OPENID_CONNECT,
+                jwtToken: 'token'
+            }, 
+            region: 'us-east-1',
+            url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
+        })
+
+        
+        const spyLink = new ApolloLink((operation, forward) => {
+            const { headers: { Authorization} } = operation.getContext();
+            expect(Authorization).toBe('token');
+            done();
+
+            return new Observable(() => {});
+        })
+        
+        const testLink = ApolloLink.from([link, spyLink]);
+
+        execute(testLink, { query }).subscribe({ })
+    });
+
+    test('Test API_KEY authorizer for queries', (done) => {
+        const query = gql`query { someQuery { aField } }`
+
+        const link = authLink({
+            auth: {
+                type: AUTH_TYPE.API_KEY,
+                apiKey: 'token'
+            }, 
+            region: 'us-east-1',
+            url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
+        })
+
+        
+        const spyLink = new ApolloLink((operation, forward) => {
+            const { headers } = operation.getContext();
+            console.log(JSON.stringify(headers));
+            expect(headers["X-Api-Key"]).toBe('token');
+            done();
+
+            return new Observable(() => {});
+        })
+        
+        const testLink = ApolloLink.from([link, spyLink]);
+
+        execute(testLink, { query }).subscribe({ })
+    });
+});

--- a/packages/aws-appsync-auth-link/jest.config.js
+++ b/packages/aws-appsync-auth-link/jest.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+    transform: {
+        "^.+\\.tsx?$": "ts-jest"
+    },
+    testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    collectCoverageFrom: [
+        "src/**/*",
+        "!src/vendor/**"
+    ],
+    moduleFileExtensions: [
+        "ts",
+        "tsx",
+        "js",
+        "jsx",
+        "json",
+        "node"
+    ],
+    testEnvironment: "node"
+};

--- a/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
+++ b/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
@@ -6,7 +6,8 @@ import { AppSyncRealTimeSubscriptionHandshakeLink } from '../../src/realtime-sub
 const query = gql`subscription { someSubscription { aField } }`
 
 class myWebSocket implements WebSocket {
-    binaryType: BinaryType;    bufferedAmount: number;
+    binaryType: BinaryType; 
+    bufferedAmount: number;
     extensions: string;
     onclose: (this: WebSocket, ev: CloseEvent) => any;
     onerror: (this: WebSocket, ev: Event) => any;
@@ -75,7 +76,7 @@ describe("RealTime subscription link", () => {
             region: 'us-east-1',
             url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
         });
-        
+
         execute(link, { query }).subscribe({
             error: (err) => {
                 console.log({ err });
@@ -112,7 +113,7 @@ describe("RealTime subscription link", () => {
             region: 'us-east-1',
             url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
         });
-        
+
         execute(link, { query }).subscribe({
             error: (err) => {
                 console.log({ err });
@@ -149,7 +150,7 @@ describe("RealTime subscription link", () => {
             region: 'us-east-1',
             url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
         });
-        
+
         execute(link, { query }).subscribe({
             error: (err) => {
                 console.log({ err });
@@ -166,5 +167,39 @@ describe("RealTime subscription link", () => {
 
         });
     });
+
+    test('Initialize WebSocket correctly for AWS_LAMBDA', (done) => {
+        expect.assertions(2);
+        jest.spyOn(Date.prototype, 'toISOString').mockImplementation(jest.fn(() => {
+            return "2019-11-13T18:47:04.733Z";
+        }));
+        AppSyncRealTimeSubscriptionHandshakeLink.createWebSocket = jest.fn((url, protocol) => {
+            expect(url).toBe('wss://xxxxx.appsync-realtime-api.amazonaws.com/graphql?header=eyJBdXRob3JpemF0aW9uIjoidG9rZW4iLCJob3N0IjoieHh4eHguYXBwc3luYy1hcGkuYW1hem9uYXdzLmNvbSJ9&payload=e30=');
+            expect(protocol).toBe('graphql-ws');
+            done();
+            return new myWebSocket();
+        });
+        const link = new AppSyncRealTimeSubscriptionHandshakeLink({
+            auth: {
+                type: AUTH_TYPE.AWS_LAMBDA,
+                token: 'token'
+            },
+            region: 'us-east-1',
+            url: 'https://xxxxx.appsync-api.amazonaws.com/graphql'
+        });
+
+        execute(link, { query }).subscribe({
+            error: (err) => {
+                fail;
+            },
+            next: (data) => {
+                done();
+            },
+            complete: () => {
+                done();
+            }
+
+        });
+    })
 
 });


### PR DESCRIPTION
*Description of changes:*

- Adding lambda authorizer for apollo v2 links (auth and subscription links)
- Small refactor on realtime-handshake

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Cypress integration test sample code

```javascript
import { AUTH_TYPE, createAuthLink } from 'aws-appsync-auth-link';
import { createSubscriptionHandshakeLink } from 'aws-appsync-subscription-link';

import { ApolloLink } from 'apollo-link';
import { createHttpLink } from 'apollo-link-http';
import ApolloClient from 'apollo-client';
import { InMemoryCache } from 'apollo-cache-inmemory';
import gql from 'graphql-tag'

const url = 'https://xxxxxxxxx.appsync-api.us-west-2.amazonaws.com/graphql';
const region = 'us-west-2';
const auth = {
    type: AUTH_TYPE.AWS_LAMBDA,
    token: 'xxxxAuthToken',
};

const httpLink = createHttpLink({ uri: url });

const link = ApolloLink.from([
    createAuthLink({ url, region, auth }),
    createSubscriptionHandshakeLink({ url, auth, region })
]);

const client = new ApolloClient({
    link,
    cache: new InMemoryCache()
})

describe('Apollo V2 links test', () => {
    it('Query', async () => {
        const LIST_BLOGS = gql`
    query {
        listBlogs{
        items {
            id
            name
        }
        }
    }`;

        const { data } = await client.query({
            query: LIST_BLOGS
        })
        expect(data.listBlogs.items).to.be.instanceOf(Array);
    });

    it('Mutation', async () => {
        const blogName = `Blog ${Date.now()}`;

        const CREATE_BLOG = gql`
            mutation ($name:String!) {
                createBlog(input: {
                name: $name
                }) {
                id
                name
                
                }
            }`;

        const { data } = await client.mutate({
            mutation: CREATE_BLOG,
            variables: {
                name: blogName
            }
        })
        expect(data.createBlog.name).to.equal(blogName);
    });

    it('Subscription', (done) => {
        const blogName = `Blog ${Date.now()}`;

        const SUBS_BLOGS = gql`
            subscription {
            onCreateBlog {
                id
                name
            }
            }`;

        const CREATE_BLOG = gql`
            mutation ($name:String!) {
                createBlog(input: {
                name: $name
                }) {
                id
                name
                
                }
            }
            `;

        client.subscribe({
            query: SUBS_BLOGS
        }).subscribe({
            next: ({ data }) => {
                expect(data.onCreateBlog.name).to.equal(blogName)
                done();
            }
        });

        new Promise(res => setTimeout(res, 2000)) //Waiting for subscription to be established
            .then(() => {
                client.mutate({
                    mutation: CREATE_BLOG,
                    variables: {
                        name: blogName
                    }
                });
            })
    });
});
```