### PR TITLE
fix: add type fix to subscription link to fix 'prepare' script

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -537,7 +537,7 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
     // Step 1: connect websocket
     try {
       await (() => {
-        return new Promise((res, rej) => {
+        return new Promise<void>((res, rej) => {
           const newSocket = AppSyncRealTimeSubscriptionHandshakeLink.createWebSocket(awsRealTimeUrl, "graphql-ws");
           newSocket.onerror = () => {
             logger(`WebSocket connection error`);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the `prepare` script fails because of a type error. This PR resolves this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
