### PR TITLE
Upgrade to @react-native-async-storage/async-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ When using this library with React Native, you need to ensure you are using the 
 | `2.x.x`               | `>= 0.60`                     |
 | `1.x.x`               | `<= 0.59`                     |
 
-If you are using React Native `0.60` and above, you also need to install `@react-native-community/netinfo` and `@react-native-community/async-storage`:
+If you are using React Native `0.60` and above, you also need to install `@react-native-community/netinfo` and `@react-native-async-storage/async-storage`:
 
 ```
-npm install --save @react-native-community/netinfo@5.9.4 @react-native-community/async-storage
+npm install --save @react-native-community/netinfo@5.9.4 @react-native-async-storage/async-storage
 ```
 or 
 ```
-yarn add @react-native-community/netinfo@5.9.4 @react-native-community/async-storage
+yarn add @react-native-community/netinfo@5.9.4 @react-native-async-storage/async-storage
 ```
 If you are using React Native `0.60+` for iOS, run the following command as an additional step: 
 ```

--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -19,7 +19,7 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "@redux-offline/redux-offline": "2.5.2-native.3",
+    "@redux-offline/redux-offline": "2.6.0-native.1",
     "apollo-cache-inmemory": "1.3.12",
     "apollo-client": "2.4.6",
     "apollo-link": "1.2.5",
@@ -38,7 +38,7 @@
     "uuid": "3.x"
   },
   "peerDependencies": {
-    "@react-native-community/async-storage": "^1.11.0",
+    "@react-native-async-storage/async-storage": "^1.11.0",
     "@react-native-community/netinfo": "^5.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
#654
#642 

*Description of changes:*
Upgrade from `@react-native-community/async-storage` to `@react-native-async-storage/async-storage`

Also upgrading `@redux-offline/redux-offline` to `2.6.0-native.1` as the old version depends on `@react-native-community/async-storage`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
