### PR TITLE
chore(aws-appsync): remove rn peerDeps

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -36,9 +36,5 @@
     "setimmediate": "^1.0.5",
     "url": "^0.11.0",
     "uuid": "3.x"
-  },
-  "peerDependencies": {
-    "@react-native-community/async-storage": "^1.11.0",
-    "@react-native-community/netinfo": "^5.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/632

*Description of changes:*
Removes RN-specific peer dependencies from aws-appsync package.json. 

Peer dependencies are supposed to be used to let consumers of a package know which host/top-level dependencies and versions thereof they need to have installed in their app in order for this package to work as expected. But those dependencies should always be needed. Peer deps should not be used for conditional dependencies that are needed in some cases but not in most, like what we’re doing here.

On NPM 6 and below, having the RN-related deps listed under peer dependencies would always throw a warning during `npm install` if customers don't have those `@react-native-community/*` dependencies installed even for customers that are not building their apps with React Native. Throwing incorrect warnings can be confusing and is not desirable behavior. 

NPM 7 now attempts to automatically install those dependencies and will throw an error when that's not possible, which makes for an even worse experience and can only be circumvented through a workaround during each install: `npm install --legacy-peer-deps` or downgrading NPM to <= 6, neither of which are acceptable solutions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
