### PR TITLE
feat: Handle AppSync Custom Domains

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -792,6 +792,7 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
       .replace("https://", "wss://")
       .replace('http://', 'ws://')
       .replace("appsync-api", "appsync-realtime-api")
-      .replace("gogi-beta", "grt-beta");
+      .replace("gogi-beta", "grt-beta")
+      .replace(/(?<!\.amazonaws\.com)\/graphql$/, s => `${s}/realtime`);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes #517 for AppSync custom domains

*Description of changes:*

The issue was originally about supporting an arbitrary URL for websockets, but since AppSync now allows Custom Domains we should be able to rely on a simple `replace` to get the correct realtime url. This PR adds on one more replace call that appends `/realtime` to the url if it is _not_ a default (i.e. `*.amazonaws.com/graphql`) url.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
