### PR TITLE
fix: Port over Amplify fix for subscription race conditions for ApolloV2

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -196,22 +196,25 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
 
   private _removeSubscriptionObserver(subscriptionId) {
     this.subscriptionObserverMap.delete(subscriptionId);
-    if (this.subscriptionObserverMap.size === 0) {
-      // Socket could be sending data to unsubscribe so is required to wait until is flushed
-      this._closeSocketWhenFlushed();
-    }
+    // Verifying for 1000ms after removing subscription in case there are new subscriptions on mount / unmount
+    setTimeout(this._closeSocketIfRequired.bind(this), 1000);
   }
 
-  private _closeSocketWhenFlushed() {
-    logger("closing WebSocket...");
-    clearTimeout(this.keepAliveTimeoutId);
+  private _closeSocketIfRequired() {
+    if (this.subscriptionObserverMap.size > 0) {
+      // There are active subscriptions on the WebSocket
+      return;
+    }
     if (!this.awsRealTimeSocket) {
       this.socketStatus = SOCKET_STATUS.CLOSED;
       return;
     }
     if (this.awsRealTimeSocket.bufferedAmount > 0) {
-      setTimeout(this._closeSocketWhenFlushed.bind(this), 1000);
+      // There is still data on the WebSocket
+      setTimeout(this._closeSocketIfRequired.bind(this), 1000);
     } else {
+      logger("closing WebSocket...");
+      clearTimeout(this.keepAliveTimeoutId);
       const tempSocket = this.awsRealTimeSocket;
       tempSocket.close(1000);
       this.awsRealTimeSocket = null;


### PR DESCRIPTION
fix: Port over Amplify fix for subscription race conditions for ApolloV2

*Issue #, if available:*
#509 

*Description of changes:*
There was a fix in [Amplify JS](https://github.com/aws-amplify/amplify-js/pull/4956) to handle subscription race conditions (for instance, on mount / unmount). Porting these over to the AppSync SDK

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
