### PR TITLE
fix: peer dependency syntax #699

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -40,6 +40,6 @@
     "uuid": "3.x"
   },
   "peerDependencies": {
-    "graphql": "0.13.0 | 14.x | 15.x"
+    "graphql": "0.13.0 || 14.x || 15.x"
   }
 }


### PR DESCRIPTION
*Issue #699*

*Description of changes:*

This PR fixes the syntax of the graphql peer dependencies in aws-appsync package (apollov2)

the syntax can for example be checked on https://semver.npmjs.com/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
