### PR TITLE
fix not signed request context in I am auth

### DIFF
--- a/packages/aws-appsync-auth-link/src/auth-link.ts
+++ b/packages/aws-appsync-auth-link/src/auth-link.ts
@@ -90,7 +90,7 @@ const iamBasedAuth = async ({ credentials, region, url }, operation, forward) =>
     const { host, path } = Url.parse(url);
 
     const formatted = {
-        ...formatAsRequest(operation, {}),
+        ...formatAsRequest(operation, origContext),
         service, region, url, host, path
     };
 


### PR DESCRIPTION
*Description of changes:*
Currently, it's not possible to add for example custom headers to the request because they will not be added to the signature. This PR change `formatAsRequest` params to instead of the empty object take request context to create a proper signature

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
