### PR TITLE
feat: Add keepAliveTimeoutMs config for AppSync WebSocket link

### DIFF
--- a/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
+++ b/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
@@ -443,7 +443,7 @@ describe("RealTime subscription link", () => {
         });
     });
 
-    test("Uses service-rovided timeout when no custom keepAliveTimeoutMs is configured", (done) => {
+    test("Uses service-provided timeout when no custom keepAliveTimeoutMs is configured", (done) => {
         const id = "abcd-efgh-ijkl-mnop";
         uuid.mockImplementationOnce(() => id);
 

--- a/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
+++ b/packages/aws-appsync-subscription-link/__tests__/link/realtime-subscription-handshake-link-test.ts
@@ -2,11 +2,14 @@ import { AUTH_TYPE } from "aws-appsync-auth-link";
 import { execute } from "@apollo/client/core";
 import gql from 'graphql-tag';
 import { AppSyncRealTimeSubscriptionHandshakeLink } from '../../src/realtime-subscription-handshake-link';
+import { MESSAGE_TYPES } from "../../src/types";
+import { v4 as uuid } from "uuid";
+jest.mock('uuid', () => ({ v4: jest.fn() }));
 
 const query = gql`subscription { someSubscription { aField } }`
 
 class myWebSocket implements WebSocket {
-    binaryType: BinaryType; 
+    binaryType: BinaryType;
     bufferedAmount: number;
     extensions: string;
     onclose: (this: WebSocket, ev: CloseEvent) => any;
@@ -359,6 +362,164 @@ describe("RealTime subscription link", () => {
             }
 
         });
-    })
+    });
+
+    test("Can use a custom keepAliveTimeoutMs", (done) => {
+        const id = "abcd-efgh-ijkl-mnop";
+        uuid.mockImplementationOnce(() => id);
+
+        expect.assertions(5);
+        jest.spyOn(Date.prototype, 'toISOString').mockImplementation(jest.fn(() => {
+            return "2019-11-13T18:47:04.733Z";
+        }));
+        AppSyncRealTimeSubscriptionHandshakeLink.createWebSocket = jest.fn((url, protocol) => {
+            expect(url).toBe('wss://apikeytest.testcustomdomain.com/graphql/realtime?header=eyJob3N0IjoiYXBpa2V5dGVzdC50ZXN0Y3VzdG9tZG9tYWluLmNvbSIsIngtYW16LWRhdGUiOiIyMDE5MTExM1QxODQ3MDRaIiwieC1hcGkta2V5IjoieHh4eHgifQ==&payload=e30=');
+            expect(protocol).toBe('graphql-ws');
+            const socket = new myWebSocket();
+
+            setTimeout(() => {
+                socket.close = () => {};
+                socket.onopen.call(socket, (undefined as unknown as Event));
+                socket.send = (msg: string) => {
+                    const { type } = JSON.parse(msg);
+
+                    switch (type) {
+                        case MESSAGE_TYPES.GQL_CONNECTION_INIT:
+                            socket.onmessage.call(socket, {
+                                data: JSON.stringify({
+                                    type: MESSAGE_TYPES.GQL_CONNECTION_ACK,
+                                    payload: {
+                                        connectionTimeoutMs: 99999,
+                                    },
+                                })
+                            } as MessageEvent);
+                            setTimeout(() => {
+                                socket.onmessage.call(socket, {
+                                    data: JSON.stringify({
+                                        id,
+                                        type: MESSAGE_TYPES.GQL_DATA,
+                                        payload: {
+                                            data: { something: 123 },
+                                        },
+                                    })
+                                } as MessageEvent);
+
+                            }, 100);
+                            break;
+                    }
+                };
+            }, 100);
+
+            return socket;
+        });
+        const link = new AppSyncRealTimeSubscriptionHandshakeLink({
+            auth: {
+                type: AUTH_TYPE.API_KEY,
+                apiKey: 'xxxxx'
+            },
+            region: 'us-west-2',
+            url: 'https://apikeytest.testcustomdomain.com/graphql',
+            keepAliveTimeoutMs: 123456,
+        });
+
+        expect(link).toBeInstanceOf(AppSyncRealTimeSubscriptionHandshakeLink);
+        expect((link as any).keepAliveTimeout).toBe(123456);
+
+        const sub = execute(link, { query }).subscribe({
+            error: (err) => {
+                console.log(JSON.stringify(err));
+                fail();
+            },
+            next: (data) => {
+                expect((link as any).keepAliveTimeout).toBe(123456);
+                done();
+                sub.unsubscribe();
+            },
+            complete: () => {
+                console.log('done with this');
+                fail();
+            }
+
+        });
+    });
+
+    test("Uses service-rovided timeout when no custom keepAliveTimeoutMs is configured", (done) => {
+        const id = "abcd-efgh-ijkl-mnop";
+        uuid.mockImplementationOnce(() => id);
+
+        expect.assertions(5);
+        jest.spyOn(Date.prototype, 'toISOString').mockImplementation(jest.fn(() => {
+            return "2019-11-13T18:47:04.733Z";
+        }));
+        AppSyncRealTimeSubscriptionHandshakeLink.createWebSocket = jest.fn((url, protocol) => {
+            expect(url).toBe('wss://apikeytest.testcustomdomain.com/graphql/realtime?header=eyJob3N0IjoiYXBpa2V5dGVzdC50ZXN0Y3VzdG9tZG9tYWluLmNvbSIsIngtYW16LWRhdGUiOiIyMDE5MTExM1QxODQ3MDRaIiwieC1hcGkta2V5IjoieHh4eHgifQ==&payload=e30=');
+            expect(protocol).toBe('graphql-ws');
+            const socket = new myWebSocket();
+
+            setTimeout(() => {
+                socket.close = () => {};
+                socket.onopen.call(socket, (undefined as unknown as Event));
+                socket.send = (msg: string) => {
+                    const { type } = JSON.parse(msg);
+
+                    switch (type) {
+                        case MESSAGE_TYPES.GQL_CONNECTION_INIT:
+                            socket.onmessage.call(socket, {
+                                data: JSON.stringify({
+                                    type: MESSAGE_TYPES.GQL_CONNECTION_ACK,
+                                    payload: {
+                                        connectionTimeoutMs: 99999,
+                                    },
+                                })
+                            } as MessageEvent);
+                            setTimeout(() => {
+                                socket.onmessage.call(socket, {
+                                    data: JSON.stringify({
+                                        id,
+                                        type: MESSAGE_TYPES.GQL_DATA,
+                                        payload: {
+                                            data: { something: 123 },
+                                        },
+                                    })
+                                } as MessageEvent);
+
+                            }, 100);
+                            break;
+                    }
+                };
+            }, 100);
+
+            return socket;
+        });
+        const link = new AppSyncRealTimeSubscriptionHandshakeLink({
+            auth: {
+                type: AUTH_TYPE.API_KEY,
+                apiKey: 'xxxxx'
+            },
+            region: 'us-west-2',
+            url: 'https://apikeytest.testcustomdomain.com/graphql',
+        });
+
+        expect(link).toBeInstanceOf(AppSyncRealTimeSubscriptionHandshakeLink);
+        expect((link as any).keepAliveTimeout).toBeUndefined();
+
+        const sub = execute(link, { query }).subscribe({
+            error: (err) => {
+                console.log(JSON.stringify(err));
+                fail();
+            },
+            next: (data) => {
+                expect((link as any).keepAliveTimeout).toBe(99999);
+                done();
+                sub.unsubscribe();
+            },
+            complete: () => {
+                console.log('done with this');
+                fail();
+            }
+
+        });
+    });
+
 
 });

--- a/packages/aws-appsync-subscription-link/src/index.ts
+++ b/packages/aws-appsync-subscription-link/src/index.ts
@@ -9,12 +9,12 @@ import { NonTerminatingLink } from "./non-terminating-link";
 import type { OperationDefinitionNode } from "graphql";
 
 import {
-  AppSyncRealTimeSubscriptionHandshakeLink
+  AppSyncRealTimeSubscriptionHandshakeLink,
 } from "./realtime-subscription-handshake-link";
-import { UrlInfo } from "./types";
+import { AppSyncRealTimeSubscriptionConfig } from "./types";
 
 function createSubscriptionHandshakeLink(
-  args: UrlInfo,
+  args: AppSyncRealTimeSubscriptionConfig,
   resultsFetcherLink?: ApolloLink
 ): ApolloLink;
 function createSubscriptionHandshakeLink(
@@ -22,7 +22,7 @@ function createSubscriptionHandshakeLink(
   resultsFetcherLink?: ApolloLink
 ): ApolloLink;
 function createSubscriptionHandshakeLink(
-  infoOrUrl: UrlInfo | string,
+  infoOrUrl: AppSyncRealTimeSubscriptionConfig | string,
   theResultsFetcherLink?: ApolloLink
 ) {
   let resultsFetcherLink: ApolloLink, subscriptionLinks: ApolloLink;
@@ -45,7 +45,7 @@ function createSubscriptionHandshakeLink(
 
               observer.next({ [CONTROL_EVENTS_KEY]: controlEvents });
 
-              return () => {};
+              return () => { };
             })
         )
       }),

--- a/packages/aws-appsync-subscription-link/src/types/index.ts
+++ b/packages/aws-appsync-subscription-link/src/types/index.ts
@@ -83,6 +83,10 @@ export type UrlInfo = {
   region: string;
 };
 
+export type AppSyncRealTimeSubscriptionConfig = UrlInfo & {
+  keepAliveTimeoutMs?: number;
+};
+
 export type ObserverQuery = {
   observer: ZenObservable.SubscriptionObserver<any>;
   query: string;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds an optional flag (`keepAliveTimeoutMs`) for the AppSync WebSocket Apollo link


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
