### PR TITLE
fix(subscription): update request return type correctly match apollo-link

### DIFF
--- a/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
@@ -50,7 +50,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
         this.subsInfoContextKey = subsInfoContextKey;
     }
 
-    request(operation: Operation) {
+    request(operation: Operation): Observable<FetchResult> | null {
         const {
             [this.subsInfoContextKey]: subsInfo,
             controlMessages: { [CONTROL_EVENTS_KEY]: controlEvents } = { [CONTROL_EVENTS_KEY]: undefined }

--- a/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
@@ -50,7 +50,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
         this.subsInfoContextKey = subsInfoContextKey;
     }
 
-    request(operation: Operation): Observable<FetchResult> | null {
+    request(operation: Operation): Observable<FetchResult> {
         const {
             [this.subsInfoContextKey]: subsInfo,
             controlMessages: { [CONTROL_EVENTS_KEY]: controlEvents } = { [CONTROL_EVENTS_KEY]: undefined }
@@ -68,7 +68,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
         } = subsInfo;
 
         if (errors && errors.length) {
-            return new Observable(observer => {
+            return new Observable<FetchResult>(observer => {
                 observer.error(new ApolloError({
                     errorMessage: 'Error during subscription handshake',
                     extraInfo: { errors },


### PR DESCRIPTION
*Description of changes:*
Continuing change from https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/566. This change was originally created by a contributor but it appears to have been abandoned. See https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/566 for full description.

See v2 change: https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/728

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
