### PR TITLE
Fixed issues when using with Angular

### DIFF
--- a/packages/aws-appsync-subscription-link/package.json
+++ b/packages/aws-appsync-subscription-link/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "aws-appsync-auth-link": "^3.0.7",
     "debug": "2.6.9",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "zen-observable-ts": "^1.2.5"
   },
   "devDependencies": {
     "@apollo/client": "^3.2.0",

--- a/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/subscription-handshake-link.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { ApolloLink, Observable, Operation, FetchResult, ApolloError } from "@apollo/client/core";
+import * as ZenObservable from 'zen-observable-ts';
 
 import { rootLogger } from "./utils";
 import * as Paho from './vendor/paho-mqtt';
@@ -50,7 +51,7 @@ export class SubscriptionHandshakeLink extends ApolloLink {
         this.subsInfoContextKey = subsInfoContextKey;
     }
 
-    request(operation: Operation) {
+    request(operation: Operation): Observable<FetchResult> | null {
         const {
             [this.subsInfoContextKey]: subsInfo,
             controlMessages: { [CONTROL_EVENTS_KEY]: controlEvents } = { [CONTROL_EVENTS_KEY]: undefined }

--- a/packages/aws-appsync-subscription-link/src/types/index.ts
+++ b/packages/aws-appsync-subscription-link/src/types/index.ts
@@ -1,4 +1,5 @@
 import { AuthOptions } from "aws-appsync-auth-link";
+import * as ZenObservable from 'zen-observable-ts';
 
 //#region Subscription link enums
 


### PR DESCRIPTION
*Issue #, if available:*  #713, #566, #727, #709

*Description of changes:*
Wasn't building in Angular projects.  Used a fix from #566 that was never merged to fix "Unknown is not assignable" error.  This was originally rejected in #727 as unnecessary if you include your Apollo components from "@apollo/client", however this is not a valid solution.    Apollo/client has a dependency on React, whereas Apollo/client/core does not.   See the following thread: https://github.com/apollographql/apollo-client/issues/7318

Fixed issues surrounding with ZenObservable.
The current release of "@Apollo/client" was including an un-released version of 1.2.5, whereas npm install was grabbing the current release of 1.1.0.   These are incompatible.   I had included 1.2.5 in my Angular project to resolve that.  This PR moves that dependency into the package's package.json.

ZenObservable still wasn't found, so I implemented the fix from Gerhardavon in #709, however the syntax had to change slightly to work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
