### PR TITLE
added check for observer being null

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -755,16 +755,21 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
         subscriptionState
       });
 
-      observer.error({
-        errors: [
-          {
-            ...new GraphQLError(`Connection failed: ${JSON.stringify(payload)}`)
-          }
-        ]
-      });
       clearTimeout(startAckTimeoutId);
 
-      observer.complete();
+      if (observer) {
+        observer.error({
+          errors: [
+            {
+              ...new GraphQLError(`Connection failed: ${JSON.stringify(payload)}`)
+            }
+          ]
+        });
+        observer.complete();
+      } else {
+        logger(`observer not found for id: ${id}`);
+      }
+      
       if (typeof subscriptionFailedCallback === "function") {
         subscriptionFailedCallback();
       }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/688

*Description of changes:*
Code does not check whether observer is null or undefined which sometimes happen.
I added a check similar to the checks being done earlier in the same function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
