### PR TITLE
fix: added check for observer to apollov2

### DIFF
--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -764,7 +764,19 @@ export class AppSyncRealTimeSubscriptionHandshakeLink extends ApolloLink {
       });
       clearTimeout(startAckTimeoutId);
 
-      observer.complete();
+      if (observer) {
+        observer.error({
+          errors: [
+            {
+              ...new GraphQLError(`Connection failed: ${JSON.stringify(payload)}`)
+            }
+          ]
+        });
+        observer.complete();
+      } else {
+        logger(`observer not found for id: ${id}`);
+      }
+
       if (typeof subscriptionFailedCallback === "function") {
         subscriptionFailedCallback();
       }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Backport https://github.com/awslabs/aws-mobile-appsync-sdk-js/pull/735

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
