### PR TITLE
chore: set max graphql version

### DIFF
--- a/packages/aws-appsync/package.json
+++ b/packages/aws-appsync/package.json
@@ -40,6 +40,6 @@
     "uuid": "3.x"
   },
   "peerDependencies": {
-    "graphql": "0.13.0 || 14.x || 15.x"
+    "graphql": "0.13.0 || 14.x || 15.0.0 - 15.3.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

Installing graphql 15.4.0 or higher results in an install error and a runtime error.

Install error:
```
$ npm install graphql@15.8.0
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: apollo-cache-inmemory@1.3.12
npm WARN Found: graphql@15.8.0
npm WARN node_modules/graphql
npm WARN   graphql@"15.8.0" from the root project
npm WARN   6 more (apollo-cache, apollo-link, apollo-link-http-common, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer graphql@"0.11.7 || ^0.12.0 || ^0.13.0 || ^14.0.0" from apollo-cache-inmemory@1.3.12
npm WARN node_modules/aws-appsync/node_modules/apollo-cache-inmemory
npm WARN   apollo-cache-inmemory@"1.3.12" from aws-appsync@4.1.7
npm WARN   node_modules/aws-appsync
npm WARN 
npm WARN Conflicting peer dependency: graphql@14.7.0
npm WARN node_modules/graphql
npm WARN   peer graphql@"0.11.7 || ^0.12.0 || ^0.13.0 || ^14.0.0" from apollo-cache-inmemory@1.3.12
npm WARN   node_modules/aws-appsync/node_modules/apollo-cache-inmemory
npm WARN     apollo-cache-inmemory@"1.3.12" from aws-appsync@4.1.7
npm WARN     node_modules/aws-appsync
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: apollo-client@2.4.6
npm WARN Found: graphql@15.8.0
npm WARN node_modules/graphql
npm WARN   graphql@"15.8.0" from the root project
npm WARN   6 more (apollo-cache, apollo-link, apollo-link-http-common, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer graphql@"^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0" from apollo-client@2.4.6
npm WARN node_modules/aws-appsync/node_modules/apollo-client
npm WARN   apollo-client@"2.4.6" from aws-appsync@4.1.7
npm WARN   node_modules/aws-appsync
npm WARN   1 more (aws-appsync-subscription-link)
npm WARN 
npm WARN Conflicting peer dependency: graphql@14.7.0
npm WARN node_modules/graphql
npm WARN   peer graphql@"^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0" from apollo-client@2.4.6
npm WARN   node_modules/aws-appsync/node_modules/apollo-client
npm WARN     apollo-client@"2.4.6" from aws-appsync@4.1.7
npm WARN     node_modules/aws-appsync
npm WARN     1 more (aws-appsync-subscription-link)
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: apollo-link@1.2.5
npm WARN Found: graphql@15.8.0
npm WARN node_modules/graphql
npm WARN   graphql@"15.8.0" from the root project
npm WARN   6 more (apollo-cache, apollo-link, apollo-link-http-common, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer graphql@"^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0" from apollo-link@1.2.5
npm WARN node_modules/aws-appsync/node_modules/apollo-link
npm WARN   apollo-link@"1.2.5" from aws-appsync@4.1.7
npm WARN   node_modules/aws-appsync
npm WARN   3 more (apollo-client, apollo-link-http, aws-appsync-subscription-link)
npm WARN 
npm WARN Conflicting peer dependency: graphql@14.7.0
npm WARN node_modules/graphql
npm WARN   peer graphql@"^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0" from apollo-link@1.2.5
npm WARN   node_modules/aws-appsync/node_modules/apollo-link
npm WARN     apollo-link@"1.2.5" from aws-appsync@4.1.7
npm WARN     node_modules/aws-appsync
npm WARN     3 more (apollo-client, apollo-link-http, aws-appsync-subscription-link)
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: apollo-link-http@1.5.8
npm WARN Found: graphql@15.8.0
npm WARN node_modules/graphql
npm WARN   graphql@"15.8.0" from the root project
npm WARN   6 more (apollo-cache, apollo-link, apollo-link-http-common, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer graphql@"^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0" from apollo-link-http@1.5.8
npm WARN node_modules/aws-appsync/node_modules/apollo-link-http
npm WARN   apollo-link-http@"1.5.8" from aws-appsync@4.1.7
npm WARN   node_modules/aws-appsync
npm WARN   1 more (aws-appsync-subscription-link)
npm WARN 
npm WARN Conflicting peer dependency: graphql@14.7.0
npm WARN node_modules/graphql
npm WARN   peer graphql@"^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0" from apollo-link-http@1.5.8
npm WARN   node_modules/aws-appsync/node_modules/apollo-link-http
npm WARN     apollo-link-http@"1.5.8" from aws-appsync@4.1.7
npm WARN     node_modules/aws-appsync
npm WARN     1 more (aws-appsync-subscription-link)

changed 1 package, and audited 271 packages in 1s

5 packages are looking for funding
  run `npm fund` for details
```

Runtime error:
```
The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
```

*Description of changes:*

Set max graphql version to 15.3.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
