### PR TITLE
fix `global` is undefined in Vite

### DIFF
--- a/packages/aws-appsync-auth-link/src/signer/signer.ts
+++ b/packages/aws-appsync-auth-link/src/signer/signer.ts
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License"). You may not use 
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
 */
-global.Buffer = global.Buffer || require('buffer').Buffer; // Required for aws sigv4 signing
+globalThis.Buffer = globalThis.Buffer || require('buffer').Buffer; // Required for aws sigv4 signing
 
 var url = require('url');
 


### PR DESCRIPTION
fix `global` is undefined in Vite.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
