### PR TITLE
➕ add buffer as a dependency so assure support on newer builds of vite.

### DIFF
--- a/packages/aws-appsync-subscription-link/package.json
+++ b/packages/aws-appsync-subscription-link/package.json
@@ -22,7 +22,8 @@
     "aws-appsync-auth-link": "^3.0.7",
     "debug": "2.6.9",
     "url": "^0.11.0",
-    "zen-observable-ts": "^1.2.5"
+    "zen-observable-ts": "^1.2.5",
+    "buffer": "6.0.3"
   },
   "devDependencies": {
     "@apollo/client": "^3.2.0",

--- a/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
+++ b/packages/aws-appsync-subscription-link/src/realtime-subscription-handshake-link.ts
@@ -26,6 +26,8 @@ import {
 } from "./types";
 import { jitteredExponentialRetry, NonRetryableError } from "./utils/retry";
 
+var Buffer = require('buffer/').Buffer
+
 const logger = rootLogger.extend("subscriptions");
 
 export const CONTROL_EVENTS_KEY = "@@controlEvents";


### PR DESCRIPTION
*Issue #, if available:*
Buffer is no longer always added by default.   so this module will fail on many of the new newer frameworks unless it is specically added as a polyfill.  
*Description of changes:*
added npm module and imported it into file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
