### PR TITLE
fix: Place paho-mqtt in correct directory when preparing package

### DIFF
--- a/packages/aws-appsync-subscription-link/package.json
+++ b/packages/aws-appsync-subscription-link/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/aws-mobile-appsync-sdk-js.git"
   },
   "scripts": {
-    "prepare": "tsc && cp -r src/vendor lib/vendor",
+    "prepare": "tsc && cp -r src/vendor/ lib/vendor",
     "test": "jest --coverage --coverageReporters=text",
     "test-watch": "jest --watch"
   },


### PR DESCRIPTION
*Description of changes:*

The latest version of aws-appsync-subscription-link for Apollo v3 - 3.1.4 - does not compile correctly due to the following error:

```
[1] ./node_modules/aws-appsync-subscription-link/lib/subscription-handshake-link.js:166:11-40 - Error: Module not found: Error: Can't resolve './vendor/paho-mqtt' in './node_modules/aws-appsync-subscription-link/lib'
```

Further deep dive into this issue indicates that the `paho-mqtt.js` file is incorrectly placed at `/lib/vendor/vendor/paho-mqtt.js`, where `vendor/` is in the path twice. This occurs since the source directory in the `cp -r` command does not have a trailing slash, which additionally copies the vendor directory again into the destination directory.

This PR introduces the trailing slash to the source directory to prevent the duplicate nested `vendor/` directory.

Resulting tarball when running `npm pack`:

```
> aws-appsync-subscription-link@3.1.4 prepare
> tsc && cp -r src/vendor/ lib/vendor

npm notice
npm notice 📦  aws-appsync-subscription-link@3.1.4
npm notice Tarball Contents
npm notice 22.5kB __tests__/link/realtime-subscription-handshake-link-test.ts
npm notice 7.5kB CHANGELOG.md
npm notice 378B jest.config.js
npm notice 487B lib/index.d.ts
npm notice 3.3kB lib/index.js
npm notice 378B lib/non-terminating-http-link.d.ts
npm notice 1.6kB lib/non-terminating-http-link.js
npm notice 557B lib/non-terminating-link.d.ts
npm notice 5.4kB lib/non-terminating-link.js
npm notice 1.6kB lib/realtime-subscription-handshake-link.d.ts
npm notice 45.7kB lib/realtime-subscription-handshake-link.js
npm notice 1.3kB lib/subscription-handshake-link.d.ts
npm notice 15.2kB lib/subscription-handshake-link.js
npm notice 2.9kB lib/types/index.d.ts
npm notice 3.3kB lib/types/index.js
npm notice 177B lib/utils/index.d.ts
npm notice 384B lib/utils/index.js
npm notice 138B lib/utils/logger.d.ts
npm notice 967B lib/utils/logger.js
npm notice 573B lib/utils/retry.d.ts
npm notice 6.3kB lib/utils/retry.js
npm notice 90.0kB lib/vendor/paho-mqtt.js
npm notice 931B package.json
npm notice Tarball Details
npm notice name: aws-appsync-subscription-link
npm notice version: 3.1.4
npm notice filename: aws-appsync-subscription-link-3.1.4.tgz
npm notice package size: 42.9 kB
npm notice unpacked size: 211.5 kB
npm notice shasum: 2e13ea5fe3e59d8a57e0ed9be61a6a30a4fbecb5
npm notice integrity: sha512-UxCZkvzXrSp5f[...]99n2p3PHNk0fQ==
npm notice total files: 23
npm notice
aws-appsync-subscription-link-3.1.4.tgz
```

I was able to additionally build this tarball into my application and compile without issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.